### PR TITLE
Fix evalution issue with PredicateArgumentEvaluator.

### DIFF
--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/PredicateArgumentEvaluator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/PredicateArgumentEvaluator.java
@@ -56,7 +56,6 @@ public class PredicateArgumentEvaluator extends Evaluator {
      * @param tester The multi-class {@link ClassificationTester} for the argument labels
      */
     public void evaluate(ClassificationTester tester, View goldView, View predictionView) {
-        super.cleanAttributes(goldView, predictionView);
         gold = (PredicateArgumentView) goldView;
         prediction = (PredicateArgumentView) predictionView;
         goldToPredictionPredicateMapping = getGoldToPredictionPredicateMapping();


### PR DESCRIPTION
- `evaluateSense` method requires attributes as part of the  evaluation.
- `evaluate` methods remotes attributes in the gold and predicted views.
- Calling `evaluate` before `evaluateSense` causes the evaluation to  fail as the attributes are missing now.