### PR TITLE
[corpusreaders] PennTreeBankReader - Fix invalid span issue in TreeView parser

### DIFF
--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TreeView.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TreeView.java
@@ -488,21 +488,20 @@ public class TreeView extends View {
             String constituentLabel = child.getLabel().getFirst();
 
             Constituent childConstituent;
-            if (start == end) {
-                childConstituent =
-                        new Constituent(constituentLabel, constituentScore, this.getViewName(),
-                                this.getTextAnnotation(), -1, 0);
+            if (start >= end) {
+                // Ignore constituents with incorrect span bounds
+                logger.debug("Constituent with incorrect span found in " + root.getViewName());
             } else {
                 childConstituent =
                         createNewConstituent(start, end, constituentLabel, constituentScore);
+
+                this.addConstituent(childConstituent);
+
+                this.addRelation(new Relation(edgeLabel, root, childConstituent, edgeScore));
+
+                Tree<Double> scoresChild = scores.getChild(childId);
+                this.addScoredParseTree(child, scoresChild, childConstituent, sentenceStartPosition);
             }
-
-            this.addConstituent(childConstituent);
-
-            this.addRelation(new Relation(edgeLabel, root, childConstituent, edgeScore));
-
-            Tree<Double> scoresChild = scores.getChild(childId);
-            this.addScoredParseTree(child, scoresChild, childConstituent, sentenceStartPosition);
         }
     }
 
@@ -526,10 +525,9 @@ public class TreeView extends View {
 
             String constituentLabel = childLabel.getFirst();
             Constituent childConstituent;
-            if (start == end) {
-                childConstituent =
-                        new Constituent(constituentLabel, 1.0, this.getViewName(),
-                                this.getTextAnnotation(), -1, 0);
+            if (start >= end) {
+                // Ignore constituents with incorrect span bounds
+                logger.debug("Constituent with incorrect span found in " + root.getViewName());
             } else {
                 childConstituent = createNewConstituent(start, end, constituentLabel, 1.0);
 
@@ -545,10 +543,11 @@ public class TreeView extends View {
                         assert false : "Expecting token: " + token + ", found " + s + " instead.";
                     }
                 }
+
+                this.addConstituent(childConstituent);
+                this.addRelation(new Relation(edgeLabel, root, childConstituent, 1.0));
+                this.addParseTree(child, childConstituent, sentenceStartPosition);
             }
-            this.addConstituent(childConstituent);
-            this.addRelation(new Relation(edgeLabel, root, childConstituent, 1.0));
-            this.addParseTree(child, childConstituent, sentenceStartPosition);
         }
     }
 

--- a/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/PropbankReaderTest.java
+++ b/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/PropbankReaderTest.java
@@ -1,3 +1,10 @@
+/**
+ * This software is released under the University of Illinois/Research and Academic Use License. See
+ * the LICENSE file in the root folder for details. Copyright (c) 2016
+ *
+ * Developed by: The Cognitive Computation Group University of Illinois at Urbana-Champaign
+ * http://cogcomp.cs.illinois.edu/
+ */
 package edu.illinois.cs.cogcomp.nlp.corpusreaders;
 
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;

--- a/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/PropbankReaderTest.java
+++ b/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/PropbankReaderTest.java
@@ -1,0 +1,50 @@
+package edu.illinois.cs.cogcomp.nlp.corpusreaders;
+
+import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.Constituent;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
+import edu.illinois.cs.cogcomp.core.stats.Counter;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PropbankReaderTest {
+
+    @Test
+    public void testParsedViews() throws Exception {
+        String treebankHome = "src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/pennTreeBank_3";
+        String propbankHome = "src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/propBank_1";
+        String[] sections = new String[] { "00" };
+        PropbankReader data = new PropbankReader(treebankHome, propbankHome, sections, ViewNames.SRL_VERB, true);
+
+        Counter<String> viewCounter = new Counter<>();
+        int numDocuments = 0;
+
+        while(data.hasNext()) {
+            TextAnnotation ta = data.next();
+
+            for (String viewName: ta.getAvailableViews()) {
+                View view = ta.getView(viewName);
+
+                for (Constituent cons: view) {
+                    assertTrue("Constituents in " + viewName + " should have valid start character offset",
+                            cons.getStartCharOffset() >= 0);
+                    assertTrue("Constituents in " + viewName + " should have valid character offsets",
+                            cons.getStartCharOffset() < cons.getEndCharOffset());
+                }
+
+                viewCounter.incrementCount(viewName);
+            }
+
+            numDocuments++;
+        }
+
+        assertEquals(3, numDocuments);
+
+        for (String viewName: viewCounter.getSortedItems()) {
+            assertEquals("ViewName_" + viewName, 3, viewCounter.getCount(viewName), 0);
+        }
+    }
+}

--- a/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/pennTreeBank_3/00/wsj_0001.mrg
+++ b/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/pennTreeBank_3/00/wsj_0001.mrg
@@ -1,0 +1,27 @@
+
+( (S 
+    (NP-SBJ 
+      (NP (NNP Pierre) (NNP Vinken) )
+      (, ,) 
+      (ADJP 
+        (NP (CD 61) (NNS years) )
+        (JJ old) )
+      (, ,) )
+    (VP (MD will) 
+      (VP (VB join) 
+        (NP (DT the) (NN board) )
+        (PP-CLR (IN as) 
+          (NP (DT a) (JJ nonexecutive) (NN director) ))
+        (NP-TMP (NNP Nov.) (CD 29) )))
+    (. .) ))
+( (S 
+    (NP-SBJ (NNP Mr.) (NNP Vinken) )
+    (VP (VBZ is) 
+      (NP-PRD 
+        (NP (NN chairman) )
+        (PP (IN of) 
+          (NP 
+            (NP (NNP Elsevier) (NNP N.V.) )
+            (, ,) 
+            (NP (DT the) (NNP Dutch) (VBG publishing) (NN group) )))))
+    (. .) ))

--- a/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/pennTreeBank_3/00/wsj_0002.mrg
+++ b/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/pennTreeBank_3/00/wsj_0002.mrg
@@ -1,0 +1,24 @@
+
+( (S 
+    (NP-SBJ-1 
+      (NP (NNP Rudolph) (NNP Agnew) )
+      (, ,) 
+      (UCP 
+        (ADJP 
+          (NP (CD 55) (NNS years) )
+          (JJ old) )
+        (CC and) 
+        (NP 
+          (NP (JJ former) (NN chairman) )
+          (PP (IN of) 
+            (NP (NNP Consolidated) (NNP Gold) (NNP Fields) (NNP PLC) ))))
+      (, ,) )
+    (VP (VBD was) 
+      (VP (VBN named) 
+        (S 
+          (NP-SBJ (-NONE- *-1) )
+          (NP-PRD 
+            (NP (DT a) (JJ nonexecutive) (NN director) )
+            (PP (IN of) 
+              (NP (DT this) (JJ British) (JJ industrial) (NN conglomerate) ))))))
+    (. .) ))

--- a/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/propBank_1/frames/frameset.dtd
+++ b/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/propBank_1/frames/frameset.dtd
@@ -1,0 +1,141 @@
+<!--
+                    dtd for predicate argument lexicon files
+
+ Each file will contain a set of predicates associated with a particular
+ lemma (including phrasal variants,  like 'keep_from', etc)
+
+ Each predicate will contain a set of roles in an entity called a roleset.  The
+ rolesets give mneumonics of the argument labels for each different set of
+ arguments.  Multiple rolesets per predicate are necessary for the accomodation
+ of different senses of the predicate.
+
+ Each roleset associates the argument labels with a set of examples
+ demonstrating some of the primary considerations in predicate argument
+ annotation for the predicate+roleset in consideration.  The examples contain
+ plain text sentences and then assign arguments to segments of the sentence.
+ The examples usually have names which are often space delimited descriptions
+ of the annotation.  The examples often have types which describe, in a
+ nutshell, some primary linguistic properties such as "benefactive" or
+ "agentive".  The type attribute may also include a phrasal particle variant
+ (eg type="keep pace") so as to indicate the guidelines for annotation of these
+ cases.
+
+ The entire document can be decorated with notes for unstructured description of
+ the information presented.
+-->
+<!ELEMENT frameset (note | predicate)*>
+<!ELEMENT note (#PCDATA)>
+
+<!ELEMENT predicate (note | roleset)*>
+<!ATTLIST predicate lemma CDATA #REQUIRED>
+
+<!--
+  The roleset's levine class attribute takes the following form:
+
+  -|\d+(\.\d+)*( \d+(\.\d+)*)*
+  
+  where '-' means there is no levine class
+  and something like 47.2 means 47.2 is a levine class of this
+  roleset.  The list of levine classes is space delimited
+-->
+  
+<!ELEMENT roleset (note*, roles, ( example | note )*)>
+<!ATTLIST roleset 
+  id   ID #REQUIRED
+  name CDATA #IMPLIED
+  vncls CDATA #IMPLIED
+  framnet CDATA #IMPLIED>
+<!ELEMENT roles   (note | role)*>
+
+<!ELEMENT role (vnrole*) >
+<!-- 
+  roles have a number (or actually a number or an "M" or an "A" associated
+  with them.  The "M" stands for modifier and the "A" stands for agent. 
+  The "A" is the agent only in the case where arg 0 is not agentive 
+  (eg verbs that can take causative constructions). This number is encoded in
+  the attribute 'n'
+
+  'f' is an attribute which may contain function tags.  The current list of 
+  available function tags are
+
+    EXT  extent
+    LOC  location
+    DIR  direction
+    NEG  negation  (not in PREDITOR)
+    MOD  general modification
+    ADV  adverbial modification
+    MNR  manner
+    PRD  secondary predication
+    REC  recipricol (eg herself, etc)
+    TMP  temporal
+    PRP  purpose - deprecated !!!
+    PNC  purpose no cause
+    CAU  cause
+  
+  additionally, function tags may be prepositions, indicating that the
+  preposition in question can be associated with the argument/role
+  presented.  For this reason, we can't restrict the values to an
+  enumeration :(.
+
+  The roles also have a 'vnr' attribute, which refers
+  to verbnet v0.2 thematic roles.  Verbnet thematic roles are 
+
+  Note That verbnet
+
+-->
+<!ATTLIST role 
+  n CDATA #REQUIRED
+  f CDATA #IMPLIED
+  descr CDATA #REQUIRED>
+
+<!ELEMENT vnrole EMPTY>
+<!ATTLIST vnrole
+  vncls CDATA #REQUIRED
+
+  vntheta (Actor1 | Actor2| Agent| Asset| Attribute| Beneficiary| Cause|
+  Destination| Experiencer| Extent| Instrument| Location| Material| Patient|
+  Patient1| Patient2| Predicate| Product| Recipient| Source| Stimulus| Theme|
+  Theme1| Theme2| Time| Topic) #REQUIRED>
+        
+
+
+<!--
+  examples may contain inflectional information and notes notes
+  After that, they contain the text of an example followed by
+  the argument structure.
+
+  The src attribute is for automatically retrieved examples
+  and refers to a roleset identifier.
+-->
+<!ELEMENT example (inflection?, note?, text, (arg | rel | note)*)>
+<!ATTLIST example
+  name CDATA #IMPLIED
+  type CDATA #IMPLIED
+  src  CDATA #IMPLIED>
+
+<!ELEMENT text (#PCDATA)>
+
+<!ELEMENT inflection EMPTY>
+<!ATTLIST inflection
+  person (third | other | ns) "ns"
+  tense  (present | past | future | ns) "ns"
+  aspect (perfect | progressive | both | ns) "ns"
+  voice  (active | passive | ns) "ns"
+  form   (infinitive | gerund | participle | full | ns) "ns">
+
+
+<!-- the n and f attributes corresponds to those of the roles
+     described above -->
+<!ELEMENT arg (#PCDATA)>
+<!ATTLIST arg
+  n CDATA #REQUIRED
+  f CDATA #IMPLIED>
+
+<!-- a rel can have an "f" attribute for a single reason, so that
+     auxilliary uses of the verb "have" can be marked as such.
+     There should be no other "f" attributes -->
+<!ELEMENT rel (#PCDATA)>
+<!ATTLIST rel
+  f CDATA #IMPLIED>
+
+

--- a/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/propBank_1/frames/join.xml
+++ b/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/propBank_1/frames/join.xml
@@ -1,0 +1,85 @@
+<!DOCTYPE frameset SYSTEM "frameset.dtd">
+<frameset>
+<predicate lemma="join">
+<note>
+  Frames file for 'join' based on sentences in financial subcorpus.
+  Verbnet class mix-22.1-2, other framed members include link.
+</note>
+
+<roleset id="join.01" name="attach" vncls="22.1-2">
+<roles>
+  <role descr="agent, entity doing the tying" n="0">
+	  <vnrole vncls="22.1-2" vntheta="Agent"/></role>
+  <role descr="patient, thing(s) being tied" n="1">
+	  <vnrole vncls="22.1-2" vntheta="Patient1"/></role>
+  <role descr="instrument, string" n="2">
+	  <vnrole vncls="22.1-2" vntheta="Patient2"/></role>
+</roles>
+
+<example name="straight transitive">
+<text>
+    Mr. Harper, a veteran of several manufacturing companies who
+    *trace* joined Campbell in 1986, will take charge of all overseas
+    operations as well as Pepperidge. 
+</text>
+        <arg n="0">*trace* -&gt;  who -&gt;  a veteran</arg>
+        <rel>joined</rel>
+        <arg n="1">Campbell</arg>
+        <arg f="TMP" n="M">in 1986</arg>
+</example>
+
+<example name="join in, as arg1">
+<text>
+    ``Anheuser is the biggest guy in the bar, and he just decided
+    *trace* to join in the barroom brawl,'' said Joseph J. Doyle, an
+    analyst with Smith Barney, Harris Upham &amp; Co. 
+</text>
+        <arg n="0">*trace* -&gt;  he</arg>
+        <rel>join</rel>
+        <arg f="in" n="1">the barroom brawl</arg>
+</example>
+
+<example name="join in, as argM-PRD">
+<text>
+    Bowing to criticism, Bear Stearns, Morgan Stanley and Oppenheimer
+    joined PaineWebber in suspending stock-index arbitrage trading for
+    their own accounts. 
+</text>
+        <arg n="0">Bear Stearns, Morgan Stanley and Oppenheimer</arg>
+        <rel>joined</rel>
+        <arg n="1">PaineWebber</arg>
+        <arg f="PRD" n="M">in suspending stock-index arbitrage trading
+        for their own accounts</arg> 
+</example>
+
+<example name="join as">
+<text>
+    In Barry Wright, Mr. Sim sees a situation ``very similar'' to the
+    one he faced when he joined Applied as president and chief
+    operating officer in 1985. 
+</text>
+        <arg n="0">he</arg>
+        <rel>joined</rel>
+        <arg n="1">Applied</arg>
+        <arg f="PRD" n="M">as president and chief operating officer</arg>
+        <arg f="TMP" n="M">in 1985</arg>
+</example>
+
+<example name="with instrument">
+  <text>
+    John joined the fragments of his coffee cup with duct tape.
+  </text>
+  <arg n="0">John</arg>
+  <rel>joined</rel>
+  <arg n="1">the fragments of his coffee cup</arg>
+  <arg f="with" n="2">duct tape</arg>
+</example>
+
+<note>
+Oddly, this is the sense predicted by verbnet, but it doesn't seem to
+occur in the corpus.  Yet?
+</note>
+
+</roleset>
+</predicate>
+</frameset>

--- a/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/propBank_1/frames/name.xml
+++ b/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/propBank_1/frames/name.xml
@@ -1,0 +1,141 @@
+<!DOCTYPE frameset SYSTEM "frameset.dtd">
+<frameset>
+<note>
+Frames file for 'name' based on survey of initial sentences from big corpus
+and comparison to 'call'.  Name is essentially equivalent to 'call' sense
+two, but 'name' Arg2 is 'call' Arg3.
+</note>
+
+<predicate lemma="name">
+<roleset id="name.01" name="call" vncls="29.3"> 
+<roles>
+  <role descr="namer" n="0">
+	  <vnrole vncls="29.3" vntheta="Agent"/></role>
+  <role descr="named" n="1">
+	  <vnrole vncls="29.3" vntheta="Theme"/></role>
+  <role descr="name of arg1" n="2">
+	  <vnrole vncls="29.3" vntheta="Predicate"/></role>
+</roles>
+
+<example name="passivized">
+<inflection aspect="ns" form="participle" person="ns" tense="ns" voice="passive"/>
+<text>
+    The issue, formally named *trace* MNB Home Equity Loan Asset
+    Backed Certificates, Series 1989, will represent interest in a
+    trust fund...  
+</text>
+        <arg f="MNR" n="M">formally</arg>
+        <rel>named</rel>
+        <arg n="1">*trace* -&gt;  The issue</arg>
+        <arg n="2">MNB Home Equity Loan Asset Backed Certificates,
+        Series 1989,</arg> 
+</example>
+
+<example name="name as AS">
+  <text>
+    Polls named Tatsunori Hara as the male symbol of Japan.
+  </text>
+  <arg n="0">Polls</arg>
+  <rel>named</rel>
+  <arg n="1">Tatsunori Hara</arg>
+  <arg f="as" n="2">the male symbol of Japan</arg>
+</example>
+
+<example name="no name mentioned">
+  <text>
+    ...the man, whom it did not name *trace*
+  </text>
+  <arg n="0">it</arg>
+  <arg f="NEG" n="M">did not</arg>
+  <rel>name</rel>
+  <arg n="1">*trace* -&gt; whom</arg>
+</example>
+
+<example name="name as infinitive">
+  <text>
+    Lee Karns named James Nichol to succeed him.
+  </text>
+  <arg n="0">Lee Karns</arg>
+  <rel>named</rel>
+  <arg n="1">James Nichol</arg>
+  <arg n="2">to succeed him</arg>
+</example>
+
+<note>
+most commonly passive:
+</note>
+
+<example name="passivized">
+  <text>
+    Both these candidates are named *trace* Rudolph Giuliani.
+  </text>
+  <rel>are named</rel>
+  <arg n="1">*trace* -&gt; both candidates</arg>
+  <arg n="2">Rudolph Giuliani</arg>
+</example>
+
+<note>
+if only one arg is present (esp in passive) it will be Arg2:
+</note>
+
+<example name="name only">
+  <text>
+    No successor was named *trace*
+  </text>
+  <rel>was named</rel>
+  <arg n="2">*trace* -&gt; successor</arg>
+</example>
+
+<example name="underlying of above">
+  <text>
+    John Smith was named successor.
+  </text>
+  <arg n="1">John Smith</arg>
+  <rel>was named</rel>
+  <arg n="2">successor</arg>
+</example>
+
+<example name="active equivalent of above">
+  <text>
+    BigHugeCo named John Smith as successor.
+  </text>
+  <arg n="0">BigHugeCo</arg>
+  <rel>named</rel>
+  <arg n="1">John Smith</arg>
+  <arg f="as" n="2">successor</arg>
+</example>
+
+</roleset>
+
+<roleset id="name.02" name="give someone else's name" vncls="-">
+<roles>
+  <role descr="namer" n="0"/>
+  <role descr="named" n="1"/>
+  <role descr="named after, namesake" n="2"/>
+</roles>
+
+<example name="ozone hole">
+  <inflection aspect="ns" form="full" person="ns" tense="ns" voice="passive"/>
+  <text>
+    As an employee of a major refrigerator and freezer manufacturer, I
+    have been heavily involved in dealing with the political
+    manifestations of the Rowland-Molina theory (named [*] after the
+    researchers who found in 1974 that chlorofluorocarbons contributed
+    to the depletion of ozone in the earth's atmosphere) and the
+    Montreal Protocol. 
+  </text>
+  <rel>named</rel>
+  <arg n="1">[*] -&gt; Rowland-Molina theory</arg>
+  <arg f="after" n="2">the
+    researchers who found in 1974 that chlorofluorocarbons contributed
+    to the depletion of ozone in the earth's atmosphere</arg>
+</example>
+
+<note>
+Very similar to the other roleset, and only to be used when there is
+an 'after' present.
+</note>
+
+</roleset>
+</predicate>
+</frameset>

--- a/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/propBank_1/frames/publish.xml
+++ b/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/propBank_1/frames/publish.xml
@@ -1,0 +1,46 @@
+<!DOCTYPE frameset SYSTEM "frameset.dtd">
+<frameset>
+<predicate lemma="publish">
+<note>
+  Frames file for 'publish' based on sentences in financial
+  subcorpus.  No access to verbnet.  No comparison.
+</note>
+
+<roleset id="publish.01" name="publish">
+<roles>
+  <role descr="publisher" n="0"/>
+  <role descr="book, report" n="1"/>
+</roles>
+
+<example name="transitive">
+<text>
+    Dow Jones publishes The Wall Street Journal, Barron's magazine,
+    and community newspapers and operates financial news services and
+    computer data bases. 
+</text>
+        <arg n="0">Dow Jones</arg>
+        <rel>publishes</rel>
+        <arg n="1">The Wall Street Journal, Barron's magazine, and
+        community newspapers</arg> 
+</example>
+
+<example name="published in">
+<text>
+    Mr. Bond indicated the consolidated debt figures, which include
+    debt of units such as Bell Group Ltd., will be published *trace*
+    soon in Bond Corp.'s 1989 annual accounts. 
+</text>
+        <arg f="MOD" n="M">will</arg>
+        <rel>published</rel>
+        <arg n="1">*trace* -&gt;  the consolidated debt figures, which
+        include debt of units such as Bell Group Ltd.</arg> 
+        <arg f="TMP" n="M">soon</arg>
+        <arg f="LOC" n="M">in Bond Corp.'s 1989 annual accounts</arg>
+</example>
+
+<note>
+</note>
+
+</roleset>
+</predicate>
+</frameset>

--- a/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/propBank_1/prop.txt
+++ b/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/propBank_1/prop.txt
@@ -1,0 +1,3 @@
+wsj/00/wsj_0001.mrg 0 8 gold join.01 vf--a 0:2-ARG0 7:0-ARGM-MOD 8:0-rel 9:1-ARG1 11:1-ARGM-PRD 15:1-ARGM-TMP
+wsj/00/wsj_0001.mrg 1 10 gold publish.01 p---a 10:0-rel 11:0-ARG0
+wsj/00/wsj_0002.mrg 0 16 gold name.01 pp--p 16:0-rel 0:2*17:0-ARG1 18:2-ARG2


### PR DESCRIPTION
- While parsing PennTreeBank, PARSE_GOLD view sometimes contains constituents with span (-1, 0) ~which cause problems with downstream feature extraction~. This happens due to the `-NONE-` label in the tree parse. 

- I was annotating `SRL_VERB` with pipeline and it was failing on some documents. I thought this was the issue but fixing the invalid span didn't fix the failures. For now, running the unit test in this PR without the fix fails.

- Fix is in `TreeView` class where we do not add the affecting constituent. I tested parsing pennTreebank. I am not sure if any other workflows would be affected by this change.

- Add two sample files and a unit test. 