### PR TITLE
illinois -> cogcomp  renamings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 This project collects a number of core libraries for Natural Language Processing (NLP) developed 
-by the University of Illinois' [Cognitive Computation Group](https://cogcomp.cs.illinois.edu).  
+by [Cognitive Computation Group](https://cogcomp.cs.illinois.edu).  
 
 ## CogComp's main NLP libraries
 
@@ -14,19 +14,19 @@ Each library contains detailed readme and instructions on how to use it. In addi
 
 | Module | Description |
 |----------|------------|
-| [illinois-nlp-pipeline](pipeline/README.md) | Provides an end-to-end NLP processing application that runs a variety of NLP tools on input text. |
-| [illinois-core-utilities](core-utilities/README.md) | Provides a set of NLP-friendly data structures and a number of  NLP-related utilities that support writing NLP applications, running experiments, etc. |
-| [illinois-corpusreaders](corpusreaders/README.md) | Provides classes to read documents from corpora into `illinois-core-utilities` data structures. |
-| [illinois-curator](curator/README.md) | Supports use of [Illinois' NLP Curator](http://cogcomp.cs.illinois.edu/page/software_view/Curator), a tool to run NLP applications as services. |
-| [illinois-edison](edison/README.md) | A library for feature extraction from `illinois-core-utilities` data structures.  | 
-| [illinois-lemmatizer](lemmatizer/README.md)  |  An application that uses [WordNet](https://wordnet.princeton.edu/) and simple rules to find the root forms of words in plain text. | 
-| [illinois-tokenizer](tokenizer/README.md) | An application that identifies sentence and word boundaries in plain text. | 
-| [illinois-pos](pos/README.md)  | An application that identifies the part of speech (e.g. verb + tense, noun + number) of each word in plain text.  |  
-| [illinois-ner](ner/README.md) | An application that identifies named entities in plain text according to two different sets of categories.  |
-| [illinois-quantifier](quantifier/README.md) | This tool detects mentions of quantities in the text, as well as normalizes it to a standard form. |
-| [illinois-inference](inference/README.md) |  A suite of unified wrappers to a set optimization libraries, as well as some basic approximate solvers. |
-| [illinois-depparse](depparse/README.md) | An application that identifies the dependency parse tree of a sentence. |
-| [illinois-prepsrl](prepsrl/README.md) | An application that identifies semantic relations expressed by prepositions and develops statistical learning models for predicting the relations. |
+| [nlp-pipeline](pipeline/README.md) | Provides an end-to-end NLP processing application that runs a variety of NLP tools on input text. |
+| [core-utilities](core-utilities/README.md) | Provides a set of NLP-friendly data structures and a number of  NLP-related utilities that support writing NLP applications, running experiments, etc. |
+| [corpusreaders](corpusreaders/README.md) | Provides classes to read documents from corpora into `core-utilities` data structures. |
+| [curator](curator/README.md) | Supports use of [Cogcomp NLP Curator](http://cogcomp.cs.illinois.edu/page/software_view/Curator), a tool to run NLP applications as services. |
+| [edison](edison/README.md) | A library for feature extraction from `core-utilities` data structures.  | 
+| [lemmatizer](lemmatizer/README.md)  |  An application that uses [WordNet](https://wordnet.princeton.edu/) and simple rules to find the root forms of words in plain text. | 
+| [tokenizer](tokenizer/README.md) | An application that identifies sentence and word boundaries in plain text. | 
+| [pos](pos/README.md)  | An application that identifies the part of speech (e.g. verb + tense, noun + number) of each word in plain text.  |  
+| [ner](ner/README.md) | An application that identifies named entities in plain text according to two different sets of categories.  |
+| [quantifier](quantifier/README.md) | This tool detects mentions of quantities in the text, as well as normalizes it to a standard form. |
+| [inference](inference/README.md) |  A suite of unified wrappers to a set optimization libraries, as well as some basic approximate solvers. |
+| [depparse](depparse/README.md) | An application that identifies the dependency parse tree of a sentence. |
+| [prepsrl](prepsrl/README.md) | An application that identifies semantic relations expressed by prepositions and develops statistical learning models for predicting the relations. |
 | [external-annotators](external/README.md) | A collection useful external annotators.  |
 
  - **Questions?** Have a look at our [FAQs](faq.md). 

--- a/chunker/README.md
+++ b/chunker/README.md
@@ -1,24 +1,6 @@
-# Illinois Chunker (Shallow Parser)
+# Cogcomp Chunker (Shallow Parser)
 
-Chunking (Shallow Parsing) is the identification of constituents (noun groups, verbs, verb groups etc.) in a sentence. The system implemented here is based of the following paper: 
-
-## Citation: 
-
-```
-@inproceedings{PunyakanokRo01,
-    author = {V. Punyakanok and D. Roth},
-    title = {The Use of Classifiers in Sequential Inference},
-    booktitle = {NIPS},
-    pages = {995--1001},
-    year = {2001},
-    publisher = {MIT Press},
-    acceptance = {25/514 (4.8\%) Oral Presentations; 152/514 (29%) overall},
-    url = " http://cogcomp.cs.illinois.edu/papers/nips01.pdf",
-    funding = {NSF98 CAREER},
-    projects = {LnI,SI,IE,NE,NLP,CCM},
-    comment = {Structured, sequential output; Sequence Prediction: HMM with classifiers, Conditional Models, Constraint Satisfaction},
-}
-```
+Chunking (Shallow Parsing) is the identification of constituents (noun groups, verbs, verb groups etc.) in a sentence. 
 
 ## Usage
 
@@ -62,7 +44,7 @@ When using`ChunkerAnnotator`, the models are loaded automatically from the direc
 Thus, to use your own models (maybe you need to train your models first; please read the following section `Training`), simply place them in this directory and they will be loaded; otherwise, the model version
 specified in this project's `pom.xml` file will be loaded from the Maven repository and used.
 
-**Note** : To use your own models, **exclude** the `illinois-chunker-model` artifact from the `illinois-chunker` dependency in your `pom.xml` to avoid potential conflicts.
+**Note** : To use your own models, **exclude** the `illinois-chunker-model` artifact from the `cogcomp-chunker` dependency in your `pom.xml` to avoid potential conflicts.
 
 ## Training
 The class [`ChunkerTrain`](src/main/java/edu/illinois/cs/cogcomp/chunker/main/ChunkerTrain.java) contains a main method that can be used to
@@ -76,7 +58,7 @@ Please also refer to [mvn_train.sh](scripts/mvn_train.sh) for an example of usag
 ## Off-the-shelf scripts
 There are a bunch of scripts provided with this package in [scripts](scripts/). Please make sure [apache maven](http://maven.apache.org/install.html) is installed before running these scripts. They should be run from the module root directory, i.e., illinois-cogcomp-nlp/chunker/. For example,
 ```
-cd illinois-cogcomp-nlp/chunker/
+cd cogcomp-nlp/chunker/
 sh scripts/mvn_demo.sh
 ```
 1. `mvn_compile.sh`: to compile the illinois-chunker module.
@@ -101,6 +83,27 @@ sh scripts/mvn_test_conll.sh (model directory) (model name)
 ## Tips for IntelliJ users
 Command line use can be found in [scripts](scripts/). But if you want to use IDEs like IntelliJ, please check the following tips before running.
 ### Import project
-Please import the `illinois-cogcomp-nlp` project from `Existing Sources` using the external model `Maven`.
+Please import the `cogcomp-nlp` project from `Existing Sources` using the external model `Maven`.
 ### Setup
 Select the `Run` tab. From the drop-down menu, select `Edit Configurations`. In the `Configuration` tab therein, specify the `Working directory` to be `$MODULE_DIR$`. Also, don't forget to set up corresponding `Program arguments`.
+
+## Further Reading 
+
+The system implemented here is based of the following paper: 
+
+```
+@inproceedings{PunyakanokRo01,
+    author = {V. Punyakanok and D. Roth},
+    title = {The Use of Classifiers in Sequential Inference},
+    booktitle = {NIPS},
+    pages = {995--1001},
+    year = {2001},
+    publisher = {MIT Press},
+    acceptance = {25/514 (4.8\%) Oral Presentations; 152/514 (29%) overall},
+    url = " http://cogcomp.cs.illinois.edu/papers/nips01.pdf",
+    funding = {NSF98 CAREER},
+    projects = {LnI,SI,IE,NE,NLP,CCM},
+    comment = {Structured, sequential output; Sequence Prediction: HMM with classifiers, Conditional Models, Constraint Satisfaction},
+}
+```
+

--- a/core-utilities/README.md
+++ b/core-utilities/README.md
@@ -1,6 +1,6 @@
-# Illinois Core-Utilities
+# Cogcomp Core-Utilities
 
-   illinois-core-utilities is a Java library that is designed to help programming NLP
+   cogcomp-core-utilities is a Java library that is designed to help programming NLP
    applications by providing a uniform representation of various NLP
    annotations of text (like parse trees, parts of speech, semantic
    roles, coreference, etc.) 
@@ -83,7 +83,7 @@ of annotations over some text.
     The simplest way to define a `TextAnnotation` is to just give the
     text to the constructor. Note that in the following example,
     `text1` consists of three sentences. The corresponding `ta1` will
-    use the sentence slitter defined in the [Learning Based Java](https://github.com/IllinoisCogComp/lbjava) (LBJava)
+    use the sentence slitter defined in the [Learning Based Java](https://github.com/CogComp/lbjava) (LBJava)
     library to split the text into sentences and further apply the
     LBJ tokenizer to tokenize the sentence.
     
@@ -296,8 +296,8 @@ for (Constituent neConstituent : ne.getConstituents()) {
 `AnnotatorService` is our super-wrapper that provides access to different annotations and free caching. 
  Currently we have two classes implementing `AnnotatorService`: 
  
-  1. [illinois-curator](../curator/README.md)
-  2. [illinois-nlp-pipeline](../pipeline/README.md)
+  1. [cogcomp-curator](../curator/README.md)
+  2. [nlp-pipeline](../pipeline/README.md)
 
 
 The image below describes the different ways of creating 

--- a/corpusreaders/README.md
+++ b/corpusreaders/README.md
@@ -1,9 +1,9 @@
-# illinois-corpusreaders
+# Cogcomp Corpusreaders
 
 ## Overview
 
 This module includes NLP Corpus readers that reads into datastructures
-provided by the `illinois-core-utilities` package.
+provided by the `cogcomp-core-utilities` package.
 
 ## List of Corpus Readers
   - PennTreebank Reader

--- a/curator/README.md
+++ b/curator/README.md
@@ -1,9 +1,9 @@
-# Illinois Curator
+# Cogcomp Curator
 
 The Curator acts as a central server that can annotate text using
 several annotators. With this package, we can connect to the Curator to
 get those annotations and build our own NLP-driven
-application. This package contains code for interacting with Curator, using the data structures from illinois-core-utilities.
+application. This package contains code for interacting with Curator, using the data structures from `cogcomo-core-utilities`.
 
 
 To use, first create a `CuratorAnnotatorService` to use the pipeline: 
@@ -55,7 +55,7 @@ for (int i = 0; i < ta.size(); i++) {
  - **Why curator tests take so much time/fail?** We have some unit tests in this module which need connection to a remote curator system. Since it is often inaccessble to CIs, we skip them on Semaphore. If you're running locally and seeing failures (or unexpected long delays on its tests) it must be that you don't have connection to Curator (in which case you can just ignore it). 
  
 
-##Citation
+## Citation
 
 J. Clarke and V. Srikumar and M. Sammons and D. Roth, An NLP Curator (or: How I Learned to Stop Worrying and Love NLP Pipelines). LREC (2012) pp.
 

--- a/depparse/README.md
+++ b/depparse/README.md
@@ -1,9 +1,6 @@
-# Illinois Dependency Parser
+# Cogcomp Dependency Parser
 
-A dependency parser built using the [Illinois Structured Learning](https://github.com/IllinoisCogComp/illinois-sl) framework.
-
-## Licensing
-To see the full license for this software, see [LICENSE](../master/LICENSE).
+A dependency parser built using the [Illinois Structured Learning](https://github.com/CogComp/illinois-sl) framework.
 
 ## Quickstart
 
@@ -25,7 +22,10 @@ It is not hard to compile. `cd` to the main directory (`edu.illinois.cs.cogcomp.
 
 ### USE
 
-The parser is meant to be used as part of the [illinois-nlp-pipeline](pipeline/README.md),
+The parser is meant to be used as part of the [cogcomp-nlp-pipeline](pipeline/README.md),
 but it can also be used programmatically either from the `DepAnnotator`
 class (sentence-by-sentence processing based on `TextAnnotation`) or via the `MainClass`
 class for batch file processing mode.
+
+## Licensing
+To see the full license for this software, see [LICENSE](../master/LICENSE).

--- a/edison/README.md
+++ b/edison/README.md
@@ -1,6 +1,6 @@
-# Illinois Edison
+# Cogcomp Edison
 
-*Edison* is a feature extraction framework that uses the data structures of [illinois-core-utilities](../core-utilities/README.md)
+*Edison* is a feature extraction framework that uses the data structures of [cogcomp-core-utilities](../core-utilities/README.md)
 to extract features used in NLP applications.
 We can define functions for feature extraction that use the tokens and one or more views. 
 This enables us to not only develop feature sets like words, n-grams, paths in parse trees, which work with a single view, 

--- a/inference/README.md
+++ b/inference/README.md
@@ -1,4 +1,4 @@
-# Illinois Inference 
+# Cogcomp Inference 
 
 This project is a suite of unified wrappers to a set optimization libraries, as well as some basic approximate solvers: 
 

--- a/lemmatizer/README.md
+++ b/lemmatizer/README.md
@@ -1,16 +1,16 @@
-# Illinois Lemmatizer
+# Cogcomp Lemmatizer
 
 ## CONTENTS
 
 1. PURPOSE  
-   1. The Illinois Lemmatizer 
+   1. The Cogcomp Lemmatizer 
    2. License 
 2. System requirements 
 3. Programmatic Use of the Lemmatizer
    1.  Lemmatizing Single Words
    2.  Lemmatizing Views
 4. Download contents 
-5. Compiling and Running the Illinois Lemmatizer
+5. Compiling and Running the Cogcomp Lemmatizer
 6. Contact Information 
 7. Developer Notes
 
@@ -47,16 +47,16 @@ While slower than stemmers, lemmatizers tend to produce more consistent,
 higher-quality output.  
 
 
-### 1.1 The Illinois Lemmatizer
+### 1.1 The Cogcomp Lemmatizer
 
-The Illinois Lemmatizer uses the JWNL library to access WordNet's
+The Cogcomp Lemmatizer uses the JWNL library to access WordNet's
 dictionaries to identify word root forms, and also uses some additional
 resources to handle prefixes and some verb forms.
 
 
 ### 1.2 License
 
-The Illinois Lemmatizer is available under a Research and Academic 
+The Cogcomp Lemmatizer is available under a Research and Academic 
 use license. For more details, visit the Curator website and click 
 the download link.
 
@@ -92,7 +92,7 @@ a) Lemmatize a single word
 -- return one or more candidate root forms of a word.
 
 b) Lemmatize a Record data structure's tokens, creating a new view.
--- this use allows easy integration with the Illinois NLP Curator, which specifies
+-- this use allows easy integration with the Cogcomp NLP Curator, which specifies
 a set of data structures for integrating the output of multiple NLP tools. 
 
 
@@ -126,8 +126,8 @@ visit [here](http://cogcomp.cs.illinois.edu/page/software_view/Curator) and in `
 
 ## 4. DOWNLOAD CONTENTS
 
-The Illinois Lemmatizer is released as either a Curator component or as 
-part of the Illinois Preprocessor bundle. The Curator downloads a tarball 
+The Cogcomp Lemmatizer is released as either a Curator component or as 
+part of the Cogcomp Preprocessor bundle. The Curator downloads a tarball 
 as part of its installation process (from which it is to be assumed you 
 have obtained this README). 
 
@@ -140,25 +140,18 @@ config -- example config file
 test/ -- input.txt and output.txt, used for making sure code is working as desired.
 ```
 
-## 5. COMPILING AND RUNNING THE ILLINOIS LEMMATIZER
+## 5. COMPILING AND RUNNING THE COGCOMP LEMMATIZER
 
 We assume that people will run this as part of the Curator, or part of the
-Illinois Preprocessor.  If you are a developer, you can use Maven to get
+Cogcomp Preprocessor.  If you are a developer, you can use Maven to get
 and compile this project.  
 
 
 ### 6. CONTACT INFORMATION
 
-You can ask questions/report problems via the CCG's software newsgroup, which you 
-can sign up for here:
+If you have any questions/issues use our issue tracker. 
 
-http://lists.cs.uiuc.edu/mailman/listinfo/illinois-ml-nlp-users
-
-
-### 7. DEVELOPER NOTES
-TODO 
-
-##Citation
+## Citation
 
 If you use this code in your research, please provide the URL for this github repository in the relevant publications.
 Thank you for citing us if you use us in your work! 

--- a/ner/README.md
+++ b/ner/README.md
@@ -1,4 +1,4 @@
-# Illinois NER Tagger
+# Cogcomp NER Tagger
 
 This is a state of the art NER tagger that tags plain text with named entities. 
 The newest version tags entities with either the "classic" 4-label type set 
@@ -12,7 +12,7 @@ This assumes you have downloaded the package from the [Cogcomp download page](ht
 
 ### Using the Menu Driven Command Line Application
 
-IllinoisNER now includes a powerful menu driven command line application. This application provides users a flexible environment
+CogcompNER now includes a powerful menu driven command line application. This application provides users a flexible environment
 supporting applications ranging from simple evaluation to complex bulk tagging. The configuration file must be passed in on the command
 line, although there is the option to modify the confiruation during at runtime.
 
@@ -148,7 +148,7 @@ $ javac -cp "dist/*:lib/*:models/*" App.java
 $ java -cp "dist/*:lib/*:models/*:." App
 ```
 
-If you have Maven installed,  you can easily incorporate the Illinois Named Entity Recognizer into
+If you have Maven installed,  you can easily incorporate the Cogcomp Named Entity Recognizer into
 your Maven project by adding the following dependencies to your pom.xml file:
 
 ```xml
@@ -162,7 +162,7 @@ your Maven project by adding the following dependencies to your pom.xml file:
 ### Configuration
 NER has numerous parameters that can be tuned during training and/or which 
 affect memory footprint and performance at runtime. These flags and default
-values can be found in the classes in package edu.illinois.cs.cogcomp.ner.config.
+values can be found in the classes in package `edu.illinois.cs.cogcomp.ner.config`.
 
 By default, NER components use contextual features in a fairly large
 context window, and so its "isSentenceLevel" parameter is set to "false".

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -1,4 +1,4 @@
-# Illinois NLP Pipeline
+# Cogcomp NLP Pipeline
 
 This software bundles some basic preprocessing steps that a lot of NLP
 applications need, with the goal of making them run locally. Some
@@ -10,7 +10,7 @@ constituency parsing, and (verb) semantic role labeling.  You can also
 use just a subset of these by changing the configuration file
 that the pipeline uses.
 
-By default, the illinois-nlp-pipeline will cache its outputs in a local
+By default, the cogcomp-nlp-pipeline will cache its outputs in a local
 directory, so that if you process overlapping data sets (or process
 the same data set multiple times), it will use a cached copy of the
 system outputs and run much faster.
@@ -22,7 +22,7 @@ please refer to the descriptions of the individual packages at the URLs
 provided. These annotations are stored as `View`s in a single `TextAnnotation`
 data structure.
 
-The Illinois NLP Pipeline provides a suite of state-of-the-art
+The Cogcomp NLP Pipeline provides a suite of state-of-the-art
 Natural Language Processing tools of varying complexity.  Some have
 specific prerequisites that must be present if you want to run them.
 The memory is expected MAXIMUM run-time memory required for the component
@@ -47,29 +47,29 @@ of several other components for which it is a dependency.
 11. Preposition SRL: <2GB
 12. Comma-SRL: <1GB, requires POS, Lemmatizer, Part-of-Speech, Named Entity Recognizer (CoNLL), Constituency Parser. 
 
-Note that individual Illinois NLP tools may depend on other tools
+Note that individual Cogcomp NLP tools may depend on other tools
 for inputs, and will not work unless those components are also active.
 If you try to run the system with an invalid configuration, it will
 print a warning about the missing components.
 
 ## Contents 
 
-If you have downloaded the Illinois NLP Pipeline as a stand-alone package,
+If you have downloaded the Cogcomp NLP Pipeline as a stand-alone package,
 it will come with all the libraries and other files it requires. 
 
 The download package is organized thus:
 ```
 config/ : configuration files
-dist/ : the Illinois Preprocessor jar
+dist/ : the Cogcomp Preprocessor jar
 lib/ : dependencies
-scripts/ : scripts to allow command-line test of the Illinois NLP Pipeline
-src/ : source code for the Illinois NLP Pipeline
-test/ : test files used for the command line test of the Illinois NLP Pipeline
+scripts/ : scripts to allow command-line test of the Cogcomp NLP Pipeline
+src/ : source code for the Cogcomp NLP Pipeline
+test/ : test files used for the command line test of the Cogcomp NLP Pipeline
 ```
-See the section "Running the Illinois NLP Pipeline" for details on running the pipeline.
+See the section "Running the Cogcomp NLP Pipeline" for details on running the pipeline.
 
 This distribution contains all the dependencies needed to run the
-Illinois NLP Pipeline. This includes configuration files for some
+Cogcomp NLP Pipeline. This includes configuration files for some
 individual components; scripts to process plain text files from the
 command line; and .jar files for the libraries used by the pipeline and
 its components.
@@ -81,7 +81,7 @@ This software has been developed to allow some of our more complex tools
 to be run completely within a single JVM, either programmatically or
 from the command line,  instead of in tandem with the [CCG NLP Curator](http://cogcomp.cs.illinois.edu/page/software_view/Curator).
 
-The illinois-nlp-pipeline package was designed to be used either
+The `cogcomp-nlp-pipeline` package was designed to be used either
 programmatically -- inline in your Java code -- or from the command line,
 using only those components you need to use for a given task.
 
@@ -94,12 +94,12 @@ tools will succeed in producing mutually consistent output.)
 One important note: if you wish to use your own tokenization, you should
 implement a class that follows the `Tokenizer` interface from
 `illinois-core-utilities`, and use it as an argument to a
-`TokenizerTextAnnotationBuilder` (also from illinois-core-utilities).
+`TokenizerTextAnnotationBuilder` (also from `cogcomp-core-utilities`).
 
 
 ### Running a Simple Command-Line Test
 Assuming you downloaded the pipeline package as a zip from the
-Illinois Cognitive Computation Group's web site. 
+Cogcomp Cognitive Computation Group's web site. 
 
 The standard distribution for this package puts dependencies in `lib/`;
 the parser model in `data/`; and the config file in `config/`. There are
@@ -184,7 +184,7 @@ is 1,000 words (fewer if you use resource-intensive annotators like
 Verb or Noun SRL).
 
 The method returns a `TextAnnotation` data structure (see the
-illinois-core-utilities package for details), which contains
+`cogcomp-core-utilities` package for details), which contains
 a View corresponding to each annotation source. Each View contains
 a set of `Constituents` and `Relations` representing the annotator output.
 Access views and constituents via:
@@ -225,7 +225,7 @@ The default configuration options are specified in the class
 `edu.illinois.cs.cogcomp.nlp.common.PipelineConfigurator`.
 Each property has a String as a key and a value.  If you want to change specific behaviors,
 such as activating or deactivating specific components, you can write non-default entries
-in a configuration file and use a ResourceManager (see illinois-core-utilities)
+in a configuration file and use a ResourceManager (see `cogcomp-core-utilities`)
 to instantiate an instance of the pipeline (any entries
 that duplicate default values will have no effect and are not required).
 

--- a/pos/README.md
+++ b/pos/README.md
@@ -1,19 +1,6 @@
-# Illinois Part-of-Speech Tagger
+# Cogcomp Part-of-Speech Tagger
 
-Part-of-Speech Tagging is the identification of words as nouns, verbs, adjectives, adverbs, etc. The system implemented 
-here is based of the following paper: 
-
-```
-@inproceedings{Even-ZoharRo01,
-    author = {Y. Even-Zohar and D. Roth},
-    title = {A Sequential Model for Multi Class Classification},
-    booktitle = {EMNLP},
-    pages = {10-19},
-    year = {2001},
-    url = " http://cogcomp.cs.illinois.edu/papers/emnlp01.pdf"
-}
-```
-
+Part-of-Speech Tagging is the identification of words as nouns, verbs, adjectives, adverbs, etc. 
 
 ## Usage
 
@@ -70,8 +57,6 @@ For example,
 
 ## Citation
 
-D. Roth and D. Zelenko, Part of Speech Tagging Using a Network of Linear Separators. Coling-Acl, The 17th International Conference on Computational Linguistics (1998) pp.1136--1142
-
 Thank you for citing us if you use us in your work! http://cogcomp.cs.illinois.edu/page/software_view/POS
 
 ```
@@ -86,4 +71,14 @@ Thank you for citing us if you use us in your work! http://cogcomp.cs.illinois.e
     funding = {NSF98,KDI},
     projects = {SI,NLP},
 }
+
+@inproceedings{Even-ZoharRo01,
+    author = {Y. Even-Zohar and D. Roth},
+    title = {A Sequential Model for Multi Class Classification},
+    booktitle = {EMNLP},
+    pages = {10-19},
+    year = {2001},
+    url = " http://cogcomp.cs.illinois.edu/papers/emnlp01.pdf"
+}
 ```
+

--- a/quantifier/README.md
+++ b/quantifier/README.md
@@ -1,4 +1,4 @@
-# Illinois Quantifier
+# Cogcomp Quantifier
 
 This tool takes plain, unannotated text as input and detects mentions
 of quantities in the text, as well as normalizes it to a standard
@@ -12,17 +12,17 @@ quantifier and also allows for training the model using your own
 training data.
 
 ## Requirements
-Compiling the Illinois Quantifier *requires* Java 1.6 or higher. If you use it a maven (sbt, etc) dependency, you need Java 1.8. 
+Compiling the Cogcomp Quantifier *requires* Java 1.6 or higher. If you use it a maven (sbt, etc) dependency, you need Java 1.8. 
 
 ## Installation
-Illinois Quantifier can be downloaded from http://cogcomp.cs.illinois.edu/page/software_view/Quantifier.
+Cogcomp Quantifier can be downloaded from http://cogcomp.cs.illinois.edu/page/software_view/Quantifier.
 
 
-## Running the Illinois Quantifier
+## Running the Cogcomp Quantifier
 
 ### Generating Quantities for plain text file
 
-The Illinois Quantifier comes bundled with a program that takes a
+The Cogcomp Quantifier comes bundled with a program that takes a
 plain, unannotated text file as input and produces that same text with
 standardized quantity annotations as output. To invoke this program,
 type:

--- a/similarity/README.md
+++ b/similarity/README.md
@@ -1,4 +1,4 @@
-# Illinois Similarity
+# Cogcomp Similarity
 
 This module specifies a simple API for NLP components that compare
 objects -- especially Strings -- and return a score indicating how

--- a/tokenizer/README.md
+++ b/tokenizer/README.md
@@ -1,18 +1,18 @@
-# Illinois Tokenizer
+# Cogcomp Tokenizer
 
 This project is based on work by Yiming Jiang, who wrote the initial
 version and evaluated CCG and Stanford tokenizers against a corpus
 drawn from OntoNotes.
 
 It has been modified in the following way: additional classes were
-written to use illinois-core-utilities data structures. The underlying
+written to use `cogcomp-core-utilities` data structures. The underlying
 tokenizer is still the LBJava `SentenceSplitter`. The evaluation code
 has not been updated to use the new `IllinoisTokenizer` class (TODO).
 
 ## HOW TO USE IT
         
 The class `edu.illinois.cs.cogcomp.annotation.TextAnnotationBuilder` 
-interface from illinois-core-utilities to create a `TextAnnotation` 
+interface from cogcomp-core-utilities to create a `TextAnnotation` 
 object with `SENTENCE` and `TOKEN` views, other builder can be provided 
 as a constructor argument to a `CachingAnnotatorService` that uses other 
 annotators in pipeline fashion.
@@ -114,7 +114,7 @@ evaluator.evaluateIllinoisTokenizer(EvaluationCriteria.ON_SAMPLE_AGAINST_GOLD_ST
 evaluator.evaluateStanfordTokenizer(EvaluationCriteria.ON_SAMPLE_AGAINST_GOLD_STANDARD);
 ```
 
-## About Illinois Tokenizer
+## About Cogcomp Tokenizer
 
 * Developed by: Yiming Jiang
 * Advised by: Professor Dan Roth


### PR DESCRIPTION
The first phase: updating "illinois" mentions In the readme files. 