### PR TITLE
no sentence-pipeline by default in the external.

### DIFF
--- a/external/src/main/java/edu/illinois/cs/cogcomp/pipeline/common/ExternalToolsConfigurator.java
+++ b/external/src/main/java/edu/illinois/cs/cogcomp/pipeline/common/ExternalToolsConfigurator.java
@@ -32,7 +32,7 @@ public class ExternalToolsConfigurator extends AnnotatorConfigurator {
      * individually, then splice the annotations together. This allows for partial annotation of
      * documents in cases where document text causes local problems for individual annotators.
      */
-    public static final Property USE_SENTENCE_PIPELINE = new Property("useSentencePipeline", FALSE);
+    public static final Property USE_SENTENCE_PIPELINE = new Property("useSentencePipeline", TRUE);
 
     /**
      * if 'true', set tokenizer to split on hyphen. Default is 'false' until CCG NLP annotator

--- a/external/src/main/java/edu/illinois/cs/cogcomp/pipeline/common/ExternalToolsConfigurator.java
+++ b/external/src/main/java/edu/illinois/cs/cogcomp/pipeline/common/ExternalToolsConfigurator.java
@@ -32,7 +32,7 @@ public class ExternalToolsConfigurator extends AnnotatorConfigurator {
      * individually, then splice the annotations together. This allows for partial annotation of
      * documents in cases where document text causes local problems for individual annotators.
      */
-    public static final Property USE_SENTENCE_PIPELINE = new Property("useSentencePipeline", TRUE);
+    public static final Property USE_SENTENCE_PIPELINE = new Property("useSentencePipeline", FALSE);
 
     /**
      * if 'true', set tokenizer to split on hyphen. Default is 'false' until CCG NLP annotator

--- a/external/src/main/java/edu/illinois/cs/cogcomp/pipeline/handlers/StanfordCorefHandler.java
+++ b/external/src/main/java/edu/illinois/cs/cogcomp/pipeline/handlers/StanfordCorefHandler.java
@@ -51,11 +51,13 @@ public class StanfordCorefHandler extends Annotator {
         pipeline.annotate(document);
         CoreferenceView vu = new CoreferenceView(viewName, ta);
 
-        for (CorefChain chain : document.get(CorefCoreAnnotations.CorefChainAnnotation.class).values()) {
+        Map corefChain = document.get(CorefCoreAnnotations.CorefChainAnnotation.class);
+        for (Object key : corefChain.keySet()) {
+            CorefChain chain = (CorefChain) corefChain.get(key);
             Constituent representative = createConstituentGivenMention(document,chain,chain.getRepresentativeMention(), ta);
             List<Constituent> consList = new ArrayList<>();
             for(CorefChain.CorefMention m : chain.getMentionsInTextualOrder()) {
-                consList.add(createConstituentGivenMention(document,chain,m, ta));
+                consList.add(createConstituentGivenMention(document, chain, m, ta));
             }
             consList.remove(representative); // remove the representative itself
             vu.addCorefEdges(representative, consList);

--- a/external/src/main/java/edu/illinois/cs/cogcomp/pipeline/main/ExternalAnnotatorServiceFactory.java
+++ b/external/src/main/java/edu/illinois/cs/cogcomp/pipeline/main/ExternalAnnotatorServiceFactory.java
@@ -60,8 +60,8 @@ public class ExternalAnnotatorServiceFactory {
                 new TokenizerTextAnnotationBuilder(new StatefulTokenizer(splitOnDash));
 
         Map<String, Annotator> annotators = buildAnnotators();
-        return isSentencePipeline ? new BasicAnnotatorService(taBldr, annotators, fullRm)
-                : new SentencePipeline(taBldr, annotators, fullRm);
+        return isSentencePipeline ? new SentencePipeline(taBldr, annotators, fullRm) : 
+                new BasicAnnotatorService(taBldr, annotators, fullRm);
     }
 
     /**

--- a/external/src/test/java/edu/illinois/cs/cogcomp/pipeline/main/ExternalAnnotatorsTest.java
+++ b/external/src/test/java/edu/illinois/cs/cogcomp/pipeline/main/ExternalAnnotatorsTest.java
@@ -31,15 +31,19 @@ public class ExternalAnnotatorsTest {
 
     private AnnotatorService service = null;
     private TextAnnotation ta = null;
+    private TextAnnotation ta2 = null;
 
     @Before
     public void init() throws IOException, AnnotatorException {
         this.service = ExternalAnnotatorServiceFactory.buildPipeline();
         this.ta = DummyTextAnnotationGenerator.generateAnnotatedTextAnnotation(false, 3);
+        String sampleText = "Shelly wanted a puppy. She asked her mommy and daddy every day for one. She told them that she would help take care of the puppy, if she could have one. Her mommy and daddy talked it over and said that they would get Shelly a new puppy. Her mommy took her to the dog pound so that she could choose one that she wanted. All the puppies at the dog pound need a loving home. Shelly went to every cage and looked each puppy in the eyes and talked to each one. After each one, she told her mommy, \"No, this isn't the one for me.\" Finally, she saw a black and white spotted one that she fell in love with. She screamed, \"Mommy, this is the one!\" Her mommy asked the worker to take the puppy out so that Shelly could make sure. Shelly and the puppy fell in love with each other right away. Shelly and her mommy took the black and white spotted puppy home with them. Shelly was so excited that she talked all the way home. After thinking hard, Shelly had a name for her new puppy, Spot.";
+        this.ta2 = service.createBasicTextAnnotation("", "", sampleText);
     }
 
     @Test
     public void testExternalAnnotators() throws AnnotatorException {
+        // sample text 1
         service.addView(ta, PathLSTMHandler.SRL_VERB_PATH_LSTM);
         assertTrue(ta.hasView(PathLSTMHandler.SRL_VERB_PATH_LSTM));
         assertTrue(ta.getView(PathLSTMHandler.SRL_VERB_PATH_LSTM).getConstituents().size() > 5);
@@ -54,5 +58,10 @@ public class ExternalAnnotatorsTest {
 
         service.addView(ta, StanfordCorefHandler.viewName);
         assertTrue(ta.hasView(StanfordCorefHandler.viewName));
+
+
+        // sample text 2
+        service.addView(ta2, StanfordCorefHandler.viewName);
+        assertTrue(ta2.getView(StanfordCorefHandler.viewName).getConstituents().size() > 40);
     }
 }


### PR DESCRIPTION
Because we have coref annotators, which goes beyond sentences. 

For future: ideally sentence-by-sentence annotations should be set in the `View`-level, rather than `TextAnnotation`-level. 