### PR TITLE
Make Sentence class throw exception for editing methods.

### DIFF
--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/Sentence.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/Sentence.java
@@ -7,13 +7,19 @@
  */
 package edu.illinois.cs.cogcomp.core.datastructures.textannotation;
 
+import edu.illinois.cs.cogcomp.core.datastructures.IntPair;
 import edu.illinois.cs.cogcomp.core.transformers.ITransformer;
+import edu.illinois.cs.cogcomp.core.utilities.AvoidUsing;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
+ * Sentence class is a read-only projection of a TextAnnotation with all views restricted to a single sentence.
+ * For making changes to any views, you will have to edit the source TextAnnotation instance that was used to
+ * create the Sentence instance.
+ *
  * @author Vivek Srikumar
  */
 public class Sentence extends AbstractTextAnnotation implements Serializable {
@@ -155,4 +161,47 @@ public class Sentence extends AbstractTextAnnotation implements Serializable {
         return this.textAnnotation.getSentenceId(this.getStartSpan());
     }
 
+    /** Overrides for forbidden methods. */
+
+    @Override
+    @AvoidUsing(reason = "Sentence class is read-only. Edit the source TextAnnotation instance directly.")
+    public void addTopKView(String viewName, List<View> view) {
+        throw new UnsupportedOperationException("Editing a Sentence instance is not supported. " +
+                "You should edit the source text annotation instance.");
+    }
+
+    @Override
+    @AvoidUsing(reason = "Sentence class is read-only. Edit the source TextAnnotation instance directly.")
+    public void addViews(String[] viewNames, View[] views) {
+        throw new UnsupportedOperationException("Editing a Sentence instance is not supported. " +
+                "You should edit the source TextAnnotation instance.");
+    }
+
+    @Override
+    @AvoidUsing(reason = "Sentence class is read-only. Edit the source TextAnnotation instance directly.")
+    public void addView(String viewName, View view) {
+        throw new UnsupportedOperationException("Editing a Sentence instance is not supported. " +
+                "You should edit the source TextAnnotation instance.");
+    }
+
+    @Override
+    @AvoidUsing(reason = "Sentence class is read-only. Edit the source TextAnnotation instance directly.")
+    public void removeView(String viewName) {
+        throw new UnsupportedOperationException("Editing a Sentence instance is not supported. " +
+                "You should edit the source TextAnnotation instance.");
+    }
+
+    @Override
+    @AvoidUsing(reason = "Sentence class is read-only. Edit the source TextAnnotation instance directly.")
+    public void removeAllViews() {
+        throw new UnsupportedOperationException("Editing a Sentence instance is not supported. " +
+                "You should edit the source TextAnnotation instance.");
+    }
+
+    @Override
+    @AvoidUsing(reason = "Sentence class is read-only. Edit the source TextAnnotation instance directly.")
+    public void setTokens(String[] tokens, IntPair[] tokenCharacterOffsets) {
+        throw new UnsupportedOperationException("Editing a Sentence instance is not supported. " +
+                "You should edit the source TextAnnotation instance.");
+    }
 }

--- a/core-utilities/src/test/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TestSentence.java
+++ b/core-utilities/src/test/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TestSentence.java
@@ -1,3 +1,10 @@
+/**
+ * This software is released under the University of Illinois/Research and Academic Use License. See
+ * the LICENSE file in the root folder for details. Copyright (c) 2016
+ *
+ * Developed by: The Cognitive Computation Group University of Illinois at Urbana-Champaign
+ * http://cogcomp.cs.illinois.edu/
+ */
 package edu.illinois.cs.cogcomp.core.datastructures.textannotation;
 
 import edu.illinois.cs.cogcomp.core.datastructures.IntPair;

--- a/core-utilities/src/test/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TestSentence.java
+++ b/core-utilities/src/test/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TestSentence.java
@@ -1,0 +1,122 @@
+package edu.illinois.cs.cogcomp.core.datastructures.textannotation;
+
+import edu.illinois.cs.cogcomp.core.datastructures.IntPair;
+import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
+import edu.illinois.cs.cogcomp.core.utilities.DummyTextAnnotationGenerator;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test the Sentence class related methods.
+ */
+public class TestSentence {
+    private static TextAnnotation ta = DummyTextAnnotationGenerator.generateAnnotatedTextAnnotation(false, 3);
+
+    /**
+     * Test that editing a Sentence instance throws an exeception.
+     */
+    @Test
+    public void testEditingThrowsException() {
+        List<Sentence> sentences = new ArrayList<>(3);
+        for (int sentenceId = 0; sentenceId < ta.getNumberOfSentences(); sentenceId++) {
+            sentences.add(ta.getSentence(sentenceId));
+        }
+
+        Throwable err = null;
+        for (Sentence sent: sentences) {
+            try {
+                View tokensView = sent.getView(ViewNames.TOKENS);
+                sent.addTopKView("TOKENS_BKP", Collections.singletonList(tokensView));
+            } catch (Throwable ex) {
+                err = ex;
+            }
+            finally {
+                assertTrue(err instanceof UnsupportedOperationException);
+                err = null;
+            }
+
+            try {
+                View tokensView = sent.getView(ViewNames.TOKENS);
+                sent.addViews(new String[] { "TOKENS_BKP" }, new View[] { tokensView });
+            } catch (Throwable ex) {
+                err = ex;
+            }
+            finally {
+                assertTrue(err instanceof UnsupportedOperationException);
+                err = null;
+            }
+
+            try {
+                View tokensView = sent.getView(ViewNames.TOKENS);
+                sent.addView("TOKENS_BKP", tokensView);
+            } catch (Throwable ex) {
+                err = ex;
+            }
+            finally {
+                assertTrue(err instanceof UnsupportedOperationException);
+                err = null;
+            }
+
+            try {
+                sent.removeView(ViewNames.LEMMA);
+            } catch (Throwable ex) {
+                err = ex;
+            }
+            finally {
+                assertTrue(err instanceof UnsupportedOperationException);
+                err = null;
+            }
+
+            try {
+                sent.removeAllViews();
+            } catch (Throwable ex) {
+                err = ex;
+            }
+            finally {
+                assertTrue(err instanceof UnsupportedOperationException);
+                err = null;
+            }
+
+            try {
+                sent.setTokens(new String[] { }, new IntPair[] { });
+            } catch (Throwable ex) {
+                err = ex;
+            }
+            finally {
+                assertTrue(err instanceof UnsupportedOperationException);
+                err = null;
+            }
+        }
+    }
+
+    /**
+     * Testing that changes made to the source TextAnnotation are propogated to the Sentence instance.
+     */
+    @Test
+    public void testEditingSourceTextAnnotation() {
+        List<Sentence> sentences = new ArrayList<>(3);
+        for (int sentenceId = 0; sentenceId < ta.getNumberOfSentences(); sentenceId++) {
+            Sentence sent = ta.getSentence(sentenceId);
+            sentences.add(sent);
+            assertTrue(sent.hasView(ViewNames.POS));
+        }
+
+        View posView = ta.getView(ViewNames.POS);
+        ta.removeView(ViewNames.POS);
+
+        for (Sentence sent: sentences) {
+            assertFalse(sent.hasView(ViewNames.POS));
+        }
+
+        ta.addView(ViewNames.POS, posView);
+
+        for (Sentence sent: sentences) {
+            assertTrue(sent.hasView(ViewNames.POS));
+        }
+    }
+}


### PR DESCRIPTION
- Sentence class is supposed to the read-only and should not be editable.

Closes #398 
