### PR TITLE
Fixed an issue in tokenizer …

### DIFF
--- a/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/TokenizerStateMachine.java
+++ b/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/TokenizerStateMachine.java
@@ -7,9 +7,6 @@
  */
 package edu.illinois.cs.cogcomp.nlp.tokenizer;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.awt.event.KeyEvent;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -53,7 +50,6 @@ import java.util.regex.Pattern;
 public class TokenizerStateMachine {
     /** valid URI schemes. */
     final static String[] schemes = {"http", "https", "ftp", "svn", "email"};
-    private static Logger logger = LoggerFactory.getLogger(TokenizerStateMachine.class);
     /** matches up to the end of the url. */
     final Pattern urlpat = Pattern
             .compile("[a-zA-Z0-9]+://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]");
@@ -673,6 +669,8 @@ public class TokenizerStateMachine {
             int lastdash = term.lastIndexOf("-");
             if (lastdash != -1)
                 term = term.substring(lastdash + 1);
+            if (term.length() == 0)
+                return false;
             ArrayList<String> abbrs = Acronyms.get(term.charAt(0));
             if (abbrs != null && abbrs.contains(term))
                 return true;

--- a/tokenizer/src/test/java/edu/illinois/cs/cogcomp/nlp/tokenizer/StatefullTokenizerTest.java
+++ b/tokenizer/src/test/java/edu/illinois/cs/cogcomp/nlp/tokenizer/StatefullTokenizerTest.java
@@ -278,14 +278,23 @@ public class StatefullTokenizerTest {
         Tokenizer.Tokenization tknzn = tkr.tokenizeTextSpan(text);
         assertEquals(tknzn.getTokens().length, 2);
     }
+    
     @Test
     public void testSplitOnDash() {
         Tokenizer tkr = new StatefulTokenizer();
         String text = "IAEA Director-General Mohamed ElBaradei ";
         Tokenizer.Tokenization tknzn = tkr.tokenizeTextSpan(text);
-        for (String token : tknzn.getTokens())
-            System.out.println("token : "+token);
         assertEquals(tknzn.getTokens().length, 6);
     }
-
+    
+    @Test
+    public void testSplitPeriodEnd() {
+        Tokenizer tkr = new StatefulTokenizer(false);
+        String text = "You see always, oh we're going to do this, we're going to--. ";
+        Tokenizer.Tokenization tknzn = tkr.tokenizeTextSpan(text);
+        assertEquals(tknzn.getTokens().length, 17);
+        tkr = new StatefulTokenizer(true);
+        tknzn = tkr.tokenizeTextSpan(text);
+        assertEquals(tknzn.getTokens().length, 18);
+    }
 }


### PR DESCRIPTION
 where multiple dashes at end of sentence resulted in index exception
when split on dash disabled.