### PR TITLE
minor update to ERE Event reader, other small fixes

### DIFF
--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/EREDocumentReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/EREDocumentReader.java
@@ -53,6 +53,9 @@ import org.slf4j.LoggerFactory;
  * LDC2016E31_DEFT_Rich_ERE_English ENR3 has -- I believe -- complete threads, where annotation files may be
  *    broken into several chunks. Taggable entities within quoted blocks are NOT marked.
  *
+ * TODO: handle DATELINE xml spans, which have content that probably should not be parsed as part of the text,
+ *     but a value we'd like to retain
+ *
  * @author redman
  * @author msammon
  */
@@ -113,6 +116,7 @@ public class EREDocumentReader extends XmlDocumentReader {
     public static final String CORPUS_TYPE = "corpusType";
     public static final String SOURCE = "source";
     public static final String TRIGGER = "trigger";
+    public static final String ORIGIN = "origin";
 
     /** aim for consistent naming */
     public static final String EntityMentionTypeAttribute = ACEReader.EntityMentionTypeAttribute;

--- a/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/EREReaderTest.java
+++ b/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/EREReaderTest.java
@@ -152,13 +152,22 @@ public class EREReaderTest {
         assertEquals(QUOTE_VAL, quoteStr);
 
 
-        runRelationReader(corpusDir);
-        runEventReader(corpusDir);
+        String wantedId = "ENG_DF_000170_20150322_F00000082.xml";
+        runRelationReader(corpusDir, wantedId);
+
+        wantedId = "ENG_DF_000170_20150322_F00000082.xml";
+
+        runEventReader(corpusDir, wantedId);
+
+        corpusDir = "/shared/corpora/corporaWeb/deft/event/LDC2016E73_TAC_KBP_2016_Eval_Core_Set_Rich_ERE_Annotation_with_Augmented_Event_Argument_v2/data/eng/nw";
+        String newWantedId = "ENG_NW_001278_20131206_F00011WGK.xml";
+
+        XmlTextAnnotation xmlTa = runEventReader(corpusDir, newWantedId);
 
     }
 
 
-    private static void runRelationReader(String corpusDir) {
+    private static XmlTextAnnotation runRelationReader(String corpusDir, String wantedId) {
         EREMentionRelationReader emr = null;
         try {
             boolean throwExceptionOnXmlTagMismatch = true;
@@ -169,7 +178,6 @@ public class EREReaderTest {
         }
         assert (emr.hasNext());
 
-        String wantedId = "ENG_DF_000170_20150322_F00000082.xml";
         String posterId = "TheOldSchool";
         XmlTextAnnotation outputXmlTa = null;
         do {
@@ -213,8 +221,6 @@ public class EREReaderTest {
 
         System.out.println(TextAnnotationPrintHelper.printCoreferenceView(cView));
 
-
-
         if (doSerialize) {
             String jsonStr = SerializationHelper.serializeToJson(output);
             try {
@@ -237,10 +243,12 @@ public class EREReaderTest {
             assertNotNull(newTa);
         }
         System.out.println("Report: " + emr.generateReport());
+
+        return outputXmlTa;
     }
 
 
-    private static void runEventReader(String corpusDir) {
+    private static XmlTextAnnotation runEventReader(String corpusDir, String wantedId) {
         EREEventReader emr = null;
         try {
             boolean throwExceptionOnXmlTagMismatch = true;
@@ -251,8 +259,6 @@ public class EREReaderTest {
         }
         assert (emr.hasNext());
 
-        String wantedId = "ENG_DF_000170_20150322_F00000082.xml";
-        String posterId = "TheOldSchool";
         XmlTextAnnotation outputXmlTa = null;
 
         do {
@@ -274,11 +280,18 @@ public class EREReaderTest {
 
         assert (eventView.getConstituents().size() > 0);
 
+        List<Constituent> triggers = eventView.getPredicates();
+        assert (triggers.size() > 0);
+        List<Relation> args = eventView.getArguments(triggers.get(0));
+        assert (args.get(0).getAttribute(ORIGIN) != null);
+        assert (args.get(0).getAttribute(REALIS) != null);
+
         System.out.println(eventView.toString());
         String report = emr.generateReport();
 
         System.out.println("Event Reader report:\n\n" + report);
 
+        return outputXmlTa;
     }
 
 

--- a/ner/README.md
+++ b/ner/README.md
@@ -140,10 +140,12 @@ public class App
 ```
 
 Note that you will need to include all the included jars on the classpath, as before.
+The following commands assume you ran `mvn install` and `mvn dependency:copy-dependencies`,
+which create the ner binary in `target/` and copies all dependency jars into `target/dependency`.
 
 ```bash
-$ javac -cp "dist/*:lib/*:models/*" App.java
-$ java -cp "dist/*:lib/*:models/*:." App
+$ javac -cp "target/*.jar:target/dependency/*" App.java
+$ java -cp "target/*.jar:target/dependency/*:." App
 ```
 
 If you have Maven installed,  you can easily incorporate the Cogcomp Named Entity Recognizer into

--- a/ner/README.md
+++ b/ner/README.md
@@ -43,11 +43,13 @@ This script requires the configuration file name.
 ### Java COMMAND LINE
 
 To annotate plain text files, navigate to the root directory (`illinois-ner/`), and run the
-following commands (plain text files are included in `test/SampleInputs/`).
+following commands (a plain text file is included in `test/`).
+NOTE: These commands assume you ran `mvn install` and `mvn dependency:copy-dependencies`,
+which create the ner binary in `target/` and copies all dependency jars into `target/dependency`.
 
 ```bash
 $ mkdir output
-$ java -Xmx3g -classpath "dist/*:lib/*:models/*" edu.illinois.cs.cogcomp.ner.NerTagger -annotate test/SampleInputs/ output/ config/ner.properties
+$ java -Xmx6g -classpath "target/*:target/dependency/*" edu.illinois.cs.cogcomp.ner.NerTagger -annotate test/SampleInputs/ output/ config/ner.properties
 ```
 
 This will annotate each file in the input directory with 4 NER categories: PER, LOC, ORG, and MISC. This may be slow. If you 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -105,11 +105,11 @@ The standard distribution for this package puts dependencies in `lib/`;
 the parser model in `data/`; and the config file in `config/`. There are
 two sample scripts that are provided to test that the
 pipeline works after you have downloaded
-it. `scripts/runPreprocessor.sh` takes as arguments a configuration file
+it. `scripts/runPipelineOnDataset.sh` takes as arguments a configuration file
 and a text file; it processes the text file according to the
 properties set in the config file, and writes output to STDOUT.
 scripts/testPreprocessor.sh is a self-contained script that calls
-`runPreprocessor.sh` with fixed arguments and compares the output to
+`runPipelineOnDataset.sh` with fixed arguments and compares the output to
 some reference output. If the new output and reference output are
 different, the script prints an error message and indicates the
 differences.
@@ -120,12 +120,12 @@ directory, run the command:
 Running the test:
 
 ```sh
-scripts/testPreprocessor.sh
+scripts/testPipeline.sh
 ```
 
 Running your own text to get a visual sense of what IllinoisPreprocessor is doing:
 ```sh
-scripts/runPreprocessor.sh  config/pipelineConfig.txt [yourTextFile] > [yourOutputFile]
+scripts/runPipelineOnDataset.sh  config/pipelineConfig.txt [yourInputFile] [yourOutputFile]
 ```
 
 ### Programmatic Use

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -100,7 +100,7 @@ Two sample scripts are provided to test that the pipeline works after you have d
 it. `scripts/runPipelineOnDataset.sh` takes as arguments a configuration file
 and a text file; it processes the text file according to the
 properties set in the config file, and writes output to STDOUT.
-scripts/testPreprocessor.sh is a self-contained script that calls
+`scripts/testPreprocessor.sh` is a self-contained script that calls
 `runPipelineOnDataset.sh` with fixed arguments and compares the output to
 some reference output. If the new output and reference output are
 different, the script prints an error message and indicates the

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -54,14 +54,9 @@ print a warning about the missing components.
 
 ## Contents 
 
-If you have downloaded the Cogcomp NLP Pipeline as a stand-alone package,
-it will come with all the libraries and other files it requires. 
-
-The download package is organized thus:
+The pipeline module is organized thus:
 ```
 config/ : configuration files
-dist/ : the Cogcomp Preprocessor jar
-lib/ : dependencies
 scripts/ : scripts to allow command-line test of the Cogcomp NLP Pipeline
 src/ : source code for the Cogcomp NLP Pipeline
 test/ : test files used for the command line test of the Cogcomp NLP Pipeline
@@ -98,13 +93,10 @@ implement a class that follows the `Tokenizer` interface from
 
 
 ### Running a Simple Command-Line Test
-Assuming you downloaded the pipeline package as a zip from the
-Cogcomp Cognitive Computation Group's web site. 
-
-The standard distribution for this package puts dependencies in `lib/`;
-the parser model in `data/`; and the config file in `config/`. There are
-two sample scripts that are provided to test that the
-pipeline works after you have downloaded
+NOTE: These commands assume you ran `mvn install` and `mvn dependency:copy-dependencies`,
+which create the pipeline binary in `target/` and copies all dependency jars into 
+`target/dependency`.  
+Two sample scripts are provided to test that the pipeline works after you have downloaded
 it. `scripts/runPipelineOnDataset.sh` takes as arguments a configuration file
 and a text file; it processes the text file according to the
 properties set in the config file, and writes output to STDOUT.

--- a/pipeline/config/pipeline-config.properties
+++ b/pipeline/config/pipeline-config.properties
@@ -1,2 +1,14 @@
 cacheDirectory  annotation-cache-test
 throwExceptionIfNotCached   false
+usePos	true
+useDep	true
+useLemma	true
+useShallowParse	true
+useNerConll	true
+useNerOntonotes	true
+useSrlVerb	true
+useSrlNom	true
+useCommaSrl	true
+useQuantifier	true
+useStanfordParse	true
+useStanfordDep	true

--- a/pipeline/scripts/runPipelineOnDataset.sh
+++ b/pipeline/scripts/runPipelineOnDataset.sh
@@ -17,9 +17,18 @@ echoerr() { echo "$@" 1>&2; }
 
 
 
-CONFIGFILE=src/test/resources/xmlcorpus.properties
-CORPUSNAME="TestCorpusPreprocessor"
-CORPUSDIR=src/test/resources/xmlcorpus
+#CONFIGFILE=src/test/resources/xmlcorpus.properties
+#CORPUSNAME="TestCorpusPreprocessor"
+#CORPUSDIR=src/test/resources/xmlcorpus
+
+if [ $# -eq 3 ]; then
+	CONFIGFILE=$1
+	CORPUSNAME=$2
+	CORPUSDIR=$3
+else
+    echo "Usage: $0 config inFile/inDir outFile/outDir"
+    exit -1
+fi
 
 
 DIST="target"
@@ -27,8 +36,8 @@ LIB="target/dependency"
 CONFIG="config"
 
 
-MAIN="edu.illinois.cs.cogcomp.nlp.main.RunPipeline"
-FLAGS="-Xmx20g -XX:MaxPermSize=1g -Xverify:all"
+MAIN="edu.illinois.cs.cogcomp.pipeline.main.RunPipeline"
+FLAGS="-Xmx30g -XX:MaxPermSize=1g -Xverify:all"
 
 
 

--- a/pipeline/scripts/testPipeline.sh
+++ b/pipeline/scripts/testPipeline.sh
@@ -9,7 +9,7 @@
 CONFIG="config"
 TEST="test"
 
-RUNSCRIPT="runPreprocessor.sh"
+RUNSCRIPT="runPipelineOnDataset.sh"
 CONFIG_FILE="$CONFIG/pipeline-config.properties"
 TEST_IN="$TEST/testIn.txt"
 TEST_OUT_TXT="$TEST/testOut.txt"
@@ -24,7 +24,7 @@ if [ ! -e $REF_FILE ]; then
 fi
 
 
-CMD="./scripts/$RUNSCRIPT $CONFIG_FILE $TEST_IN $TEST_OUT_TXT $TEST_OUT_SER"
+CMD="./scripts/$RUNSCRIPT $CONFIG_FILE $TEST_IN $TEST_OUT_TXT"
 
 echo "$0: running command '$CMD'"
 

--- a/pipeline/scripts/testPipeline.sh
+++ b/pipeline/scripts/testPipeline.sh
@@ -4,7 +4,7 @@
 # PURPOSE: test the Illinois Temporal Extractor using a fixed
 #   input file and reference output. 
 # executor must have read/write/execute privileges in test dir. 
-#
+# must first run 'mvn install' and 'mvn dependency:copy-dependencies"
 
 CONFIG="config"
 TEST="test"

--- a/pipeline/src/test/java/edu/illinois/cs/cogcomp/pipeline/main/ViewConstructorPipelineTest.java
+++ b/pipeline/src/test/java/edu/illinois/cs/cogcomp/pipeline/main/ViewConstructorPipelineTest.java
@@ -58,7 +58,13 @@ public class ViewConstructorPipelineTest {
         System.out.println("found " + ta.getView(ViewNames.POS).getConstituents() + " POS constituents." );
     }
 
-    @Test
+    /**
+     * NOTE: this test cannot be run as part of test suite as it tries to
+     *   open a default cache already used elsewhere by other tests, which will
+     *   not be closed properly. This test is useful to verify that the particular
+     *   factory method works, but must be run separately.
+     */
+//    @Test
     public void testPosPipeline() {
         String input = null;
         try {

--- a/pipeline/test/referenceOut.txt
+++ b/pipeline/test/referenceOut.txt
@@ -1,0 +1,22903 @@
+{
+  "corpusId": "",
+  "id": "",
+  "text": "Bernstein, a CNN contributor whose reporting for the Washington Post helped topple Nixon in the 1970s, said Sunday on CNN\u0027s \"Reliable Sources\" that he is concerned Republicans in Congress haven\u0027t voiced more skepticism of President Trump\u0027s decision to fire FBI Director James Comey last week.\n\nComey\u0027s department was investigating potential ties between the Trump campaign and Russia.\n\nRelated: Trump\u0027s chief of staff: \u0027We\u0027ve looked at\u0027 changing libel laws\n\n\"The Republicans during Watergate were heroic. They are the ones who said, \u0027What did the president know, and when did he know it?\u0027\" Bernstein said.\n\nHe added that those Republicans investigated and supported the impeachment of Nixon \"because they were willing to see the truth served.\" Nixon resigned before a trial in the U.S. Senate could happen.\n\nBernstein said there has not been \"something similar\" yet from Republicans today. He said while \"numerous\" members of the party have been quietly critical of Trump, conservative leadership has been either silent or supportive of him. \n",
+  "tokens": [
+    "Bernstein",
+    ",",
+    "a",
+    "CNN",
+    "contributor",
+    "whose",
+    "reporting",
+    "for",
+    "the",
+    "Washington",
+    "Post",
+    "helped",
+    "topple",
+    "Nixon",
+    "in",
+    "the",
+    "1970s",
+    ",",
+    "said",
+    "Sunday",
+    "on",
+    "CNN",
+    "\u0027s",
+    "\"",
+    "Reliable",
+    "Sources",
+    "\"",
+    "that",
+    "he",
+    "is",
+    "concerned",
+    "Republicans",
+    "in",
+    "Congress",
+    "have",
+    "n\u0027t",
+    "voiced",
+    "more",
+    "skepticism",
+    "of",
+    "President",
+    "Trump",
+    "\u0027s",
+    "decision",
+    "to",
+    "fire",
+    "FBI",
+    "Director",
+    "James",
+    "Comey",
+    "last",
+    "week",
+    ".",
+    "Comey",
+    "\u0027s",
+    "department",
+    "was",
+    "investigating",
+    "potential",
+    "ties",
+    "between",
+    "the",
+    "Trump",
+    "campaign",
+    "and",
+    "Russia",
+    ".",
+    "Related",
+    ":",
+    "Trump",
+    "\u0027s",
+    "chief",
+    "of",
+    "staff",
+    ":",
+    "\u0027",
+    "We",
+    "\u0027ve",
+    "looked",
+    "at",
+    "\u0027",
+    "changing",
+    "libel",
+    "laws",
+    "\"",
+    "The",
+    "Republicans",
+    "during",
+    "Watergate",
+    "were",
+    "heroic",
+    ".",
+    "They",
+    "are",
+    "the",
+    "ones",
+    "who",
+    "said",
+    ",",
+    "\u0027",
+    "What",
+    "did",
+    "the",
+    "president",
+    "know",
+    ",",
+    "and",
+    "when",
+    "did",
+    "he",
+    "know",
+    "it",
+    "?",
+    "\u0027",
+    "\"",
+    "Bernstein",
+    "said",
+    ".",
+    "He",
+    "added",
+    "that",
+    "those",
+    "Republicans",
+    "investigated",
+    "and",
+    "supported",
+    "the",
+    "impeachment",
+    "of",
+    "Nixon",
+    "\"",
+    "because",
+    "they",
+    "were",
+    "willing",
+    "to",
+    "see",
+    "the",
+    "truth",
+    "served",
+    ".",
+    "\"",
+    "Nixon",
+    "resigned",
+    "before",
+    "a",
+    "trial",
+    "in",
+    "the",
+    "U",
+    ".",
+    "S.",
+    "Senate",
+    "could",
+    "happen",
+    ".",
+    "Bernstein",
+    "said",
+    "there",
+    "has",
+    "not",
+    "been",
+    "\"",
+    "something",
+    "similar",
+    "\"",
+    "yet",
+    "from",
+    "Republicans",
+    "today",
+    ".",
+    "He",
+    "said",
+    "while",
+    "\"",
+    "numerous",
+    "\"",
+    "members",
+    "of",
+    "the",
+    "party",
+    "have",
+    "been",
+    "quietly",
+    "critical",
+    "of",
+    "Trump",
+    ",",
+    "conservative",
+    "leadership",
+    "has",
+    "been",
+    "either",
+    "silent",
+    "or",
+    "supportive",
+    "of",
+    "him",
+    "."
+  ],
+  "tokenOffsets": [
+    {
+      "form": "Bernstein",
+      "startCharOffset": 0,
+      "endCharOffset": 9
+    },
+    {
+      "form": ",",
+      "startCharOffset": 9,
+      "endCharOffset": 10
+    },
+    {
+      "form": "a",
+      "startCharOffset": 11,
+      "endCharOffset": 12
+    },
+    {
+      "form": "CNN",
+      "startCharOffset": 13,
+      "endCharOffset": 16
+    },
+    {
+      "form": "contributor",
+      "startCharOffset": 17,
+      "endCharOffset": 28
+    },
+    {
+      "form": "whose",
+      "startCharOffset": 29,
+      "endCharOffset": 34
+    },
+    {
+      "form": "reporting",
+      "startCharOffset": 35,
+      "endCharOffset": 44
+    },
+    {
+      "form": "for",
+      "startCharOffset": 45,
+      "endCharOffset": 48
+    },
+    {
+      "form": "the",
+      "startCharOffset": 49,
+      "endCharOffset": 52
+    },
+    {
+      "form": "Washington",
+      "startCharOffset": 53,
+      "endCharOffset": 63
+    },
+    {
+      "form": "Post",
+      "startCharOffset": 64,
+      "endCharOffset": 68
+    },
+    {
+      "form": "helped",
+      "startCharOffset": 69,
+      "endCharOffset": 75
+    },
+    {
+      "form": "topple",
+      "startCharOffset": 76,
+      "endCharOffset": 82
+    },
+    {
+      "form": "Nixon",
+      "startCharOffset": 83,
+      "endCharOffset": 88
+    },
+    {
+      "form": "in",
+      "startCharOffset": 89,
+      "endCharOffset": 91
+    },
+    {
+      "form": "the",
+      "startCharOffset": 92,
+      "endCharOffset": 95
+    },
+    {
+      "form": "1970s",
+      "startCharOffset": 96,
+      "endCharOffset": 101
+    },
+    {
+      "form": ",",
+      "startCharOffset": 101,
+      "endCharOffset": 102
+    },
+    {
+      "form": "said",
+      "startCharOffset": 103,
+      "endCharOffset": 107
+    },
+    {
+      "form": "Sunday",
+      "startCharOffset": 108,
+      "endCharOffset": 114
+    },
+    {
+      "form": "on",
+      "startCharOffset": 115,
+      "endCharOffset": 117
+    },
+    {
+      "form": "CNN",
+      "startCharOffset": 118,
+      "endCharOffset": 121
+    },
+    {
+      "form": "\u0027s",
+      "startCharOffset": 121,
+      "endCharOffset": 123
+    },
+    {
+      "form": "\"",
+      "startCharOffset": 124,
+      "endCharOffset": 125
+    },
+    {
+      "form": "Reliable",
+      "startCharOffset": 125,
+      "endCharOffset": 133
+    },
+    {
+      "form": "Sources",
+      "startCharOffset": 134,
+      "endCharOffset": 141
+    },
+    {
+      "form": "\"",
+      "startCharOffset": 141,
+      "endCharOffset": 142
+    },
+    {
+      "form": "that",
+      "startCharOffset": 143,
+      "endCharOffset": 147
+    },
+    {
+      "form": "he",
+      "startCharOffset": 148,
+      "endCharOffset": 150
+    },
+    {
+      "form": "is",
+      "startCharOffset": 151,
+      "endCharOffset": 153
+    },
+    {
+      "form": "concerned",
+      "startCharOffset": 154,
+      "endCharOffset": 163
+    },
+    {
+      "form": "Republicans",
+      "startCharOffset": 164,
+      "endCharOffset": 175
+    },
+    {
+      "form": "in",
+      "startCharOffset": 176,
+      "endCharOffset": 178
+    },
+    {
+      "form": "Congress",
+      "startCharOffset": 179,
+      "endCharOffset": 187
+    },
+    {
+      "form": "have",
+      "startCharOffset": 188,
+      "endCharOffset": 192
+    },
+    {
+      "form": "n\u0027t",
+      "startCharOffset": 192,
+      "endCharOffset": 195
+    },
+    {
+      "form": "voiced",
+      "startCharOffset": 196,
+      "endCharOffset": 202
+    },
+    {
+      "form": "more",
+      "startCharOffset": 203,
+      "endCharOffset": 207
+    },
+    {
+      "form": "skepticism",
+      "startCharOffset": 208,
+      "endCharOffset": 218
+    },
+    {
+      "form": "of",
+      "startCharOffset": 219,
+      "endCharOffset": 221
+    },
+    {
+      "form": "President",
+      "startCharOffset": 222,
+      "endCharOffset": 231
+    },
+    {
+      "form": "Trump",
+      "startCharOffset": 232,
+      "endCharOffset": 237
+    },
+    {
+      "form": "\u0027s",
+      "startCharOffset": 237,
+      "endCharOffset": 239
+    },
+    {
+      "form": "decision",
+      "startCharOffset": 240,
+      "endCharOffset": 248
+    },
+    {
+      "form": "to",
+      "startCharOffset": 249,
+      "endCharOffset": 251
+    },
+    {
+      "form": "fire",
+      "startCharOffset": 252,
+      "endCharOffset": 256
+    },
+    {
+      "form": "FBI",
+      "startCharOffset": 257,
+      "endCharOffset": 260
+    },
+    {
+      "form": "Director",
+      "startCharOffset": 261,
+      "endCharOffset": 269
+    },
+    {
+      "form": "James",
+      "startCharOffset": 270,
+      "endCharOffset": 275
+    },
+    {
+      "form": "Comey",
+      "startCharOffset": 276,
+      "endCharOffset": 281
+    },
+    {
+      "form": "last",
+      "startCharOffset": 282,
+      "endCharOffset": 286
+    },
+    {
+      "form": "week",
+      "startCharOffset": 287,
+      "endCharOffset": 291
+    },
+    {
+      "form": ".",
+      "startCharOffset": 291,
+      "endCharOffset": 292
+    },
+    {
+      "form": "Comey",
+      "startCharOffset": 294,
+      "endCharOffset": 299
+    },
+    {
+      "form": "\u0027s",
+      "startCharOffset": 299,
+      "endCharOffset": 301
+    },
+    {
+      "form": "department",
+      "startCharOffset": 302,
+      "endCharOffset": 312
+    },
+    {
+      "form": "was",
+      "startCharOffset": 313,
+      "endCharOffset": 316
+    },
+    {
+      "form": "investigating",
+      "startCharOffset": 317,
+      "endCharOffset": 330
+    },
+    {
+      "form": "potential",
+      "startCharOffset": 331,
+      "endCharOffset": 340
+    },
+    {
+      "form": "ties",
+      "startCharOffset": 341,
+      "endCharOffset": 345
+    },
+    {
+      "form": "between",
+      "startCharOffset": 346,
+      "endCharOffset": 353
+    },
+    {
+      "form": "the",
+      "startCharOffset": 354,
+      "endCharOffset": 357
+    },
+    {
+      "form": "Trump",
+      "startCharOffset": 358,
+      "endCharOffset": 363
+    },
+    {
+      "form": "campaign",
+      "startCharOffset": 364,
+      "endCharOffset": 372
+    },
+    {
+      "form": "and",
+      "startCharOffset": 373,
+      "endCharOffset": 376
+    },
+    {
+      "form": "Russia",
+      "startCharOffset": 377,
+      "endCharOffset": 383
+    },
+    {
+      "form": ".",
+      "startCharOffset": 383,
+      "endCharOffset": 384
+    },
+    {
+      "form": "Related",
+      "startCharOffset": 386,
+      "endCharOffset": 393
+    },
+    {
+      "form": ":",
+      "startCharOffset": 393,
+      "endCharOffset": 394
+    },
+    {
+      "form": "Trump",
+      "startCharOffset": 395,
+      "endCharOffset": 400
+    },
+    {
+      "form": "\u0027s",
+      "startCharOffset": 400,
+      "endCharOffset": 402
+    },
+    {
+      "form": "chief",
+      "startCharOffset": 403,
+      "endCharOffset": 408
+    },
+    {
+      "form": "of",
+      "startCharOffset": 409,
+      "endCharOffset": 411
+    },
+    {
+      "form": "staff",
+      "startCharOffset": 412,
+      "endCharOffset": 417
+    },
+    {
+      "form": ":",
+      "startCharOffset": 417,
+      "endCharOffset": 418
+    },
+    {
+      "form": "\u0027",
+      "startCharOffset": 419,
+      "endCharOffset": 420
+    },
+    {
+      "form": "We",
+      "startCharOffset": 420,
+      "endCharOffset": 422
+    },
+    {
+      "form": "\u0027ve",
+      "startCharOffset": 422,
+      "endCharOffset": 425
+    },
+    {
+      "form": "looked",
+      "startCharOffset": 426,
+      "endCharOffset": 432
+    },
+    {
+      "form": "at",
+      "startCharOffset": 433,
+      "endCharOffset": 435
+    },
+    {
+      "form": "\u0027",
+      "startCharOffset": 435,
+      "endCharOffset": 436
+    },
+    {
+      "form": "changing",
+      "startCharOffset": 437,
+      "endCharOffset": 445
+    },
+    {
+      "form": "libel",
+      "startCharOffset": 446,
+      "endCharOffset": 451
+    },
+    {
+      "form": "laws",
+      "startCharOffset": 452,
+      "endCharOffset": 456
+    },
+    {
+      "form": "\"",
+      "startCharOffset": 458,
+      "endCharOffset": 459
+    },
+    {
+      "form": "The",
+      "startCharOffset": 459,
+      "endCharOffset": 462
+    },
+    {
+      "form": "Republicans",
+      "startCharOffset": 463,
+      "endCharOffset": 474
+    },
+    {
+      "form": "during",
+      "startCharOffset": 475,
+      "endCharOffset": 481
+    },
+    {
+      "form": "Watergate",
+      "startCharOffset": 482,
+      "endCharOffset": 491
+    },
+    {
+      "form": "were",
+      "startCharOffset": 492,
+      "endCharOffset": 496
+    },
+    {
+      "form": "heroic",
+      "startCharOffset": 497,
+      "endCharOffset": 503
+    },
+    {
+      "form": ".",
+      "startCharOffset": 503,
+      "endCharOffset": 504
+    },
+    {
+      "form": "They",
+      "startCharOffset": 505,
+      "endCharOffset": 509
+    },
+    {
+      "form": "are",
+      "startCharOffset": 510,
+      "endCharOffset": 513
+    },
+    {
+      "form": "the",
+      "startCharOffset": 514,
+      "endCharOffset": 517
+    },
+    {
+      "form": "ones",
+      "startCharOffset": 518,
+      "endCharOffset": 522
+    },
+    {
+      "form": "who",
+      "startCharOffset": 523,
+      "endCharOffset": 526
+    },
+    {
+      "form": "said",
+      "startCharOffset": 527,
+      "endCharOffset": 531
+    },
+    {
+      "form": ",",
+      "startCharOffset": 531,
+      "endCharOffset": 532
+    },
+    {
+      "form": "\u0027",
+      "startCharOffset": 533,
+      "endCharOffset": 534
+    },
+    {
+      "form": "What",
+      "startCharOffset": 534,
+      "endCharOffset": 538
+    },
+    {
+      "form": "did",
+      "startCharOffset": 539,
+      "endCharOffset": 542
+    },
+    {
+      "form": "the",
+      "startCharOffset": 543,
+      "endCharOffset": 546
+    },
+    {
+      "form": "president",
+      "startCharOffset": 547,
+      "endCharOffset": 556
+    },
+    {
+      "form": "know",
+      "startCharOffset": 557,
+      "endCharOffset": 561
+    },
+    {
+      "form": ",",
+      "startCharOffset": 561,
+      "endCharOffset": 562
+    },
+    {
+      "form": "and",
+      "startCharOffset": 563,
+      "endCharOffset": 566
+    },
+    {
+      "form": "when",
+      "startCharOffset": 567,
+      "endCharOffset": 571
+    },
+    {
+      "form": "did",
+      "startCharOffset": 572,
+      "endCharOffset": 575
+    },
+    {
+      "form": "he",
+      "startCharOffset": 576,
+      "endCharOffset": 578
+    },
+    {
+      "form": "know",
+      "startCharOffset": 579,
+      "endCharOffset": 583
+    },
+    {
+      "form": "it",
+      "startCharOffset": 584,
+      "endCharOffset": 586
+    },
+    {
+      "form": "?",
+      "startCharOffset": 586,
+      "endCharOffset": 587
+    },
+    {
+      "form": "\u0027",
+      "startCharOffset": 587,
+      "endCharOffset": 588
+    },
+    {
+      "form": "\"",
+      "startCharOffset": 588,
+      "endCharOffset": 589
+    },
+    {
+      "form": "Bernstein",
+      "startCharOffset": 590,
+      "endCharOffset": 599
+    },
+    {
+      "form": "said",
+      "startCharOffset": 600,
+      "endCharOffset": 604
+    },
+    {
+      "form": ".",
+      "startCharOffset": 604,
+      "endCharOffset": 605
+    },
+    {
+      "form": "He",
+      "startCharOffset": 607,
+      "endCharOffset": 609
+    },
+    {
+      "form": "added",
+      "startCharOffset": 610,
+      "endCharOffset": 615
+    },
+    {
+      "form": "that",
+      "startCharOffset": 616,
+      "endCharOffset": 620
+    },
+    {
+      "form": "those",
+      "startCharOffset": 621,
+      "endCharOffset": 626
+    },
+    {
+      "form": "Republicans",
+      "startCharOffset": 627,
+      "endCharOffset": 638
+    },
+    {
+      "form": "investigated",
+      "startCharOffset": 639,
+      "endCharOffset": 651
+    },
+    {
+      "form": "and",
+      "startCharOffset": 652,
+      "endCharOffset": 655
+    },
+    {
+      "form": "supported",
+      "startCharOffset": 656,
+      "endCharOffset": 665
+    },
+    {
+      "form": "the",
+      "startCharOffset": 666,
+      "endCharOffset": 669
+    },
+    {
+      "form": "impeachment",
+      "startCharOffset": 670,
+      "endCharOffset": 681
+    },
+    {
+      "form": "of",
+      "startCharOffset": 682,
+      "endCharOffset": 684
+    },
+    {
+      "form": "Nixon",
+      "startCharOffset": 685,
+      "endCharOffset": 690
+    },
+    {
+      "form": "\"",
+      "startCharOffset": 691,
+      "endCharOffset": 692
+    },
+    {
+      "form": "because",
+      "startCharOffset": 692,
+      "endCharOffset": 699
+    },
+    {
+      "form": "they",
+      "startCharOffset": 700,
+      "endCharOffset": 704
+    },
+    {
+      "form": "were",
+      "startCharOffset": 705,
+      "endCharOffset": 709
+    },
+    {
+      "form": "willing",
+      "startCharOffset": 710,
+      "endCharOffset": 717
+    },
+    {
+      "form": "to",
+      "startCharOffset": 718,
+      "endCharOffset": 720
+    },
+    {
+      "form": "see",
+      "startCharOffset": 721,
+      "endCharOffset": 724
+    },
+    {
+      "form": "the",
+      "startCharOffset": 725,
+      "endCharOffset": 728
+    },
+    {
+      "form": "truth",
+      "startCharOffset": 729,
+      "endCharOffset": 734
+    },
+    {
+      "form": "served",
+      "startCharOffset": 735,
+      "endCharOffset": 741
+    },
+    {
+      "form": ".",
+      "startCharOffset": 741,
+      "endCharOffset": 742
+    },
+    {
+      "form": "\"",
+      "startCharOffset": 742,
+      "endCharOffset": 743
+    },
+    {
+      "form": "Nixon",
+      "startCharOffset": 744,
+      "endCharOffset": 749
+    },
+    {
+      "form": "resigned",
+      "startCharOffset": 750,
+      "endCharOffset": 758
+    },
+    {
+      "form": "before",
+      "startCharOffset": 759,
+      "endCharOffset": 765
+    },
+    {
+      "form": "a",
+      "startCharOffset": 766,
+      "endCharOffset": 767
+    },
+    {
+      "form": "trial",
+      "startCharOffset": 768,
+      "endCharOffset": 773
+    },
+    {
+      "form": "in",
+      "startCharOffset": 774,
+      "endCharOffset": 776
+    },
+    {
+      "form": "the",
+      "startCharOffset": 777,
+      "endCharOffset": 780
+    },
+    {
+      "form": "U",
+      "startCharOffset": 781,
+      "endCharOffset": 782
+    },
+    {
+      "form": ".",
+      "startCharOffset": 782,
+      "endCharOffset": 783
+    },
+    {
+      "form": "S.",
+      "startCharOffset": 783,
+      "endCharOffset": 785
+    },
+    {
+      "form": "Senate",
+      "startCharOffset": 786,
+      "endCharOffset": 792
+    },
+    {
+      "form": "could",
+      "startCharOffset": 793,
+      "endCharOffset": 798
+    },
+    {
+      "form": "happen",
+      "startCharOffset": 799,
+      "endCharOffset": 805
+    },
+    {
+      "form": ".",
+      "startCharOffset": 805,
+      "endCharOffset": 806
+    },
+    {
+      "form": "Bernstein",
+      "startCharOffset": 808,
+      "endCharOffset": 817
+    },
+    {
+      "form": "said",
+      "startCharOffset": 818,
+      "endCharOffset": 822
+    },
+    {
+      "form": "there",
+      "startCharOffset": 823,
+      "endCharOffset": 828
+    },
+    {
+      "form": "has",
+      "startCharOffset": 829,
+      "endCharOffset": 832
+    },
+    {
+      "form": "not",
+      "startCharOffset": 833,
+      "endCharOffset": 836
+    },
+    {
+      "form": "been",
+      "startCharOffset": 837,
+      "endCharOffset": 841
+    },
+    {
+      "form": "\"",
+      "startCharOffset": 842,
+      "endCharOffset": 843
+    },
+    {
+      "form": "something",
+      "startCharOffset": 843,
+      "endCharOffset": 852
+    },
+    {
+      "form": "similar",
+      "startCharOffset": 853,
+      "endCharOffset": 860
+    },
+    {
+      "form": "\"",
+      "startCharOffset": 860,
+      "endCharOffset": 861
+    },
+    {
+      "form": "yet",
+      "startCharOffset": 862,
+      "endCharOffset": 865
+    },
+    {
+      "form": "from",
+      "startCharOffset": 866,
+      "endCharOffset": 870
+    },
+    {
+      "form": "Republicans",
+      "startCharOffset": 871,
+      "endCharOffset": 882
+    },
+    {
+      "form": "today",
+      "startCharOffset": 883,
+      "endCharOffset": 888
+    },
+    {
+      "form": ".",
+      "startCharOffset": 888,
+      "endCharOffset": 889
+    },
+    {
+      "form": "He",
+      "startCharOffset": 890,
+      "endCharOffset": 892
+    },
+    {
+      "form": "said",
+      "startCharOffset": 893,
+      "endCharOffset": 897
+    },
+    {
+      "form": "while",
+      "startCharOffset": 898,
+      "endCharOffset": 903
+    },
+    {
+      "form": "\"",
+      "startCharOffset": 904,
+      "endCharOffset": 905
+    },
+    {
+      "form": "numerous",
+      "startCharOffset": 905,
+      "endCharOffset": 913
+    },
+    {
+      "form": "\"",
+      "startCharOffset": 913,
+      "endCharOffset": 914
+    },
+    {
+      "form": "members",
+      "startCharOffset": 915,
+      "endCharOffset": 922
+    },
+    {
+      "form": "of",
+      "startCharOffset": 923,
+      "endCharOffset": 925
+    },
+    {
+      "form": "the",
+      "startCharOffset": 926,
+      "endCharOffset": 929
+    },
+    {
+      "form": "party",
+      "startCharOffset": 930,
+      "endCharOffset": 935
+    },
+    {
+      "form": "have",
+      "startCharOffset": 936,
+      "endCharOffset": 940
+    },
+    {
+      "form": "been",
+      "startCharOffset": 941,
+      "endCharOffset": 945
+    },
+    {
+      "form": "quietly",
+      "startCharOffset": 946,
+      "endCharOffset": 953
+    },
+    {
+      "form": "critical",
+      "startCharOffset": 954,
+      "endCharOffset": 962
+    },
+    {
+      "form": "of",
+      "startCharOffset": 963,
+      "endCharOffset": 965
+    },
+    {
+      "form": "Trump",
+      "startCharOffset": 966,
+      "endCharOffset": 971
+    },
+    {
+      "form": ",",
+      "startCharOffset": 971,
+      "endCharOffset": 972
+    },
+    {
+      "form": "conservative",
+      "startCharOffset": 973,
+      "endCharOffset": 985
+    },
+    {
+      "form": "leadership",
+      "startCharOffset": 986,
+      "endCharOffset": 996
+    },
+    {
+      "form": "has",
+      "startCharOffset": 997,
+      "endCharOffset": 1000
+    },
+    {
+      "form": "been",
+      "startCharOffset": 1001,
+      "endCharOffset": 1005
+    },
+    {
+      "form": "either",
+      "startCharOffset": 1006,
+      "endCharOffset": 1012
+    },
+    {
+      "form": "silent",
+      "startCharOffset": 1013,
+      "endCharOffset": 1019
+    },
+    {
+      "form": "or",
+      "startCharOffset": 1020,
+      "endCharOffset": 1022
+    },
+    {
+      "form": "supportive",
+      "startCharOffset": 1023,
+      "endCharOffset": 1033
+    },
+    {
+      "form": "of",
+      "startCharOffset": 1034,
+      "endCharOffset": 1036
+    },
+    {
+      "form": "him",
+      "startCharOffset": 1037,
+      "endCharOffset": 1040
+    },
+    {
+      "form": ".",
+      "startCharOffset": 1040,
+      "endCharOffset": 1041
+    }
+  ],
+  "sentences": {
+    "generator": "UserSpecified",
+    "score": 1.0,
+    "sentenceEndPositions": [
+      53,
+      67,
+      92,
+      118,
+      142,
+      156,
+      171,
+      199
+    ]
+  },
+  "views": [
+    {
+      "viewName": "BROWN_CLUSTERS_1000",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.SpanLabelView",
+          "viewName": "BROWN_CLUSTERS_1000",
+          "generator": "BrownClusters",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "11101010",
+              "score": 1.0,
+              "start": 0,
+              "end": 1
+            },
+            {
+              "label": "0111110",
+              "score": 1.0,
+              "start": 1,
+              "end": 2
+            },
+            {
+              "label": "110000",
+              "score": 1.0,
+              "start": 2,
+              "end": 3
+            },
+            {
+              "label": "11100010110",
+              "score": 1.0,
+              "start": 2,
+              "end": 3
+            },
+            {
+              "label": "11010110110",
+              "score": 1.0,
+              "start": 3,
+              "end": 4
+            },
+            {
+              "label": "10111001011",
+              "score": 1.0,
+              "start": 4,
+              "end": 5
+            },
+            {
+              "label": "0111101101100",
+              "score": 1.0,
+              "start": 5,
+              "end": 6
+            },
+            {
+              "label": "11110110111111111",
+              "score": 1.0,
+              "start": 6,
+              "end": 7
+            },
+            {
+              "label": "01011010",
+              "score": 1.0,
+              "start": 7,
+              "end": 8
+            },
+            {
+              "label": "110010",
+              "score": 1.0,
+              "start": 8,
+              "end": 9
+            },
+            {
+              "label": "11101101111111",
+              "score": 1.0,
+              "start": 9,
+              "end": 10
+            },
+            {
+              "label": "010111111110",
+              "score": 1.0,
+              "start": 9,
+              "end": 10
+            },
+            {
+              "label": "11100000",
+              "score": 1.0,
+              "start": 10,
+              "end": 11
+            },
+            {
+              "label": "1011110110",
+              "score": 1.0,
+              "start": 10,
+              "end": 11
+            },
+            {
+              "label": "111101011110111",
+              "score": 1.0,
+              "start": 11,
+              "end": 12
+            },
+            {
+              "label": "11110000000",
+              "score": 1.0,
+              "start": 12,
+              "end": 13
+            },
+            {
+              "label": "11101010",
+              "score": 1.0,
+              "start": 13,
+              "end": 14
+            },
+            {
+              "label": "01010",
+              "score": 1.0,
+              "start": 14,
+              "end": 15
+            },
+            {
+              "label": "11011111010011",
+              "score": 1.0,
+              "start": 14,
+              "end": 15
+            },
+            {
+              "label": "110010",
+              "score": 1.0,
+              "start": 15,
+              "end": 16
+            },
+            {
+              "label": "101100001",
+              "score": 1.0,
+              "start": 16,
+              "end": 17
+            },
+            {
+              "label": "0111110",
+              "score": 1.0,
+              "start": 17,
+              "end": 18
+            },
+            {
+              "label": "011100",
+              "score": 1.0,
+              "start": 18,
+              "end": 19
+            },
+            {
+              "label": "111101001101",
+              "score": 1.0,
+              "start": 18,
+              "end": 19
+            },
+            {
+              "label": "1111101101",
+              "score": 1.0,
+              "start": 19,
+              "end": 20
+            },
+            {
+              "label": "1010110011110",
+              "score": 1.0,
+              "start": 20,
+              "end": 21
+            },
+            {
+              "label": "11111110",
+              "score": 1.0,
+              "start": 20,
+              "end": 21
+            },
+            {
+              "label": "11010110110",
+              "score": 1.0,
+              "start": 21,
+              "end": 22
+            },
+            {
+              "label": "01111110",
+              "score": 1.0,
+              "start": 22,
+              "end": 23
+            },
+            {
+              "label": "1110010",
+              "score": 1.0,
+              "start": 23,
+              "end": 24
+            },
+            {
+              "label": "11100010010",
+              "score": 1.0,
+              "start": 24,
+              "end": 25
+            },
+            {
+              "label": "11101011110",
+              "score": 1.0,
+              "start": 25,
+              "end": 26
+            },
+            {
+              "label": "1110010",
+              "score": 1.0,
+              "start": 26,
+              "end": 27
+            },
+            {
+              "label": "01111000",
+              "score": 1.0,
+              "start": 27,
+              "end": 28
+            },
+            {
+              "label": "111010010",
+              "score": 1.0,
+              "start": 28,
+              "end": 29
+            },
+            {
+              "label": "011011011",
+              "score": 1.0,
+              "start": 29,
+              "end": 30
+            },
+            {
+              "label": "11110110111010",
+              "score": 1.0,
+              "start": 30,
+              "end": 31
+            },
+            {
+              "label": "101001010",
+              "score": 1.0,
+              "start": 31,
+              "end": 32
+            },
+            {
+              "label": "01010",
+              "score": 1.0,
+              "start": 32,
+              "end": 33
+            },
+            {
+              "label": "11011111010011",
+              "score": 1.0,
+              "start": 32,
+              "end": 33
+            },
+            {
+              "label": "11101101111110",
+              "score": 1.0,
+              "start": 33,
+              "end": 34
+            },
+            {
+              "label": "011011100",
+              "score": 1.0,
+              "start": 34,
+              "end": 35
+            },
+            {
+              "label": "111100001010",
+              "score": 1.0,
+              "start": 35,
+              "end": 36
+            },
+            {
+              "label": "111101010110111",
+              "score": 1.0,
+              "start": 36,
+              "end": 37
+            },
+            {
+              "label": "110111000",
+              "score": 1.0,
+              "start": 37,
+              "end": 38
+            },
+            {
+              "label": "100110100",
+              "score": 1.0,
+              "start": 38,
+              "end": 39
+            },
+            {
+              "label": "0100",
+              "score": 1.0,
+              "start": 39,
+              "end": 40
+            },
+            {
+              "label": "111011101010",
+              "score": 1.0,
+              "start": 40,
+              "end": 41
+            },
+            {
+              "label": "111011000",
+              "score": 1.0,
+              "start": 41,
+              "end": 42
+            },
+            {
+              "label": "01111110",
+              "score": 1.0,
+              "start": 42,
+              "end": 43
+            },
+            {
+              "label": "10111001101",
+              "score": 1.0,
+              "start": 43,
+              "end": 44
+            },
+            {
+              "label": "10101110111110",
+              "score": 1.0,
+              "start": 43,
+              "end": 44
+            },
+            {
+              "label": "10101110000",
+              "score": 1.0,
+              "start": 44,
+              "end": 45
+            },
+            {
+              "label": "01100",
+              "score": 1.0,
+              "start": 44,
+              "end": 45
+            },
+            {
+              "label": "10011111111",
+              "score": 1.0,
+              "start": 45,
+              "end": 46
+            },
+            {
+              "label": "1011010110",
+              "score": 1.0,
+              "start": 46,
+              "end": 47
+            },
+            {
+              "label": "1110111100010",
+              "score": 1.0,
+              "start": 47,
+              "end": 48
+            },
+            {
+              "label": "11100111",
+              "score": 1.0,
+              "start": 48,
+              "end": 49
+            },
+            {
+              "label": "11111111010",
+              "score": 1.0,
+              "start": 50,
+              "end": 51
+            },
+            {
+              "label": "11011110010",
+              "score": 1.0,
+              "start": 50,
+              "end": 51
+            },
+            {
+              "label": "11111011101",
+              "score": 1.0,
+              "start": 51,
+              "end": 52
+            },
+            {
+              "label": "00",
+              "score": 1.0,
+              "start": 52,
+              "end": 53
+            },
+            {
+              "label": "01111110",
+              "score": 1.0,
+              "start": 54,
+              "end": 55
+            },
+            {
+              "label": "1011111111111",
+              "score": 1.0,
+              "start": 55,
+              "end": 56
+            },
+            {
+              "label": "011011010",
+              "score": 1.0,
+              "start": 56,
+              "end": 57
+            },
+            {
+              "label": "1111011010110",
+              "score": 1.0,
+              "start": 57,
+              "end": 58
+            },
+            {
+              "label": "110111110110101",
+              "score": 1.0,
+              "start": 58,
+              "end": 59
+            },
+            {
+              "label": "10101111011",
+              "score": 1.0,
+              "start": 59,
+              "end": 60
+            },
+            {
+              "label": "0101100110",
+              "score": 1.0,
+              "start": 60,
+              "end": 61
+            },
+            {
+              "label": "110010",
+              "score": 1.0,
+              "start": 61,
+              "end": 62
+            },
+            {
+              "label": "111011000",
+              "score": 1.0,
+              "start": 62,
+              "end": 63
+            },
+            {
+              "label": "1011101101110",
+              "score": 1.0,
+              "start": 63,
+              "end": 64
+            },
+            {
+              "label": "0111111101",
+              "score": 1.0,
+              "start": 64,
+              "end": 65
+            },
+            {
+              "label": "1110110111011",
+              "score": 1.0,
+              "start": 65,
+              "end": 66
+            },
+            {
+              "label": "00",
+              "score": 1.0,
+              "start": 66,
+              "end": 67
+            },
+            {
+              "label": "11101111111100",
+              "score": 1.0,
+              "start": 67,
+              "end": 68
+            },
+            {
+              "label": "0111111111110",
+              "score": 1.0,
+              "start": 68,
+              "end": 69
+            },
+            {
+              "label": "111011000",
+              "score": 1.0,
+              "start": 69,
+              "end": 70
+            },
+            {
+              "label": "01111110",
+              "score": 1.0,
+              "start": 70,
+              "end": 71
+            },
+            {
+              "label": "111011101100",
+              "score": 1.0,
+              "start": 71,
+              "end": 72
+            },
+            {
+              "label": "0100",
+              "score": 1.0,
+              "start": 72,
+              "end": 73
+            },
+            {
+              "label": "10111110110",
+              "score": 1.0,
+              "start": 73,
+              "end": 74
+            },
+            {
+              "label": "0111111111110",
+              "score": 1.0,
+              "start": 74,
+              "end": 75
+            },
+            {
+              "label": "1111011011000",
+              "score": 1.0,
+              "start": 75,
+              "end": 76
+            },
+            {
+              "label": "1110100000",
+              "score": 1.0,
+              "start": 76,
+              "end": 77
+            },
+            {
+              "label": "01101111111111",
+              "score": 1.0,
+              "start": 77,
+              "end": 78
+            },
+            {
+              "label": "1111010110101",
+              "score": 1.0,
+              "start": 78,
+              "end": 79
+            },
+            {
+              "label": "111110001111",
+              "score": 1.0,
+              "start": 79,
+              "end": 80
+            },
+            {
+              "label": "01011110",
+              "score": 1.0,
+              "start": 79,
+              "end": 80
+            },
+            {
+              "label": "1111011011000",
+              "score": 1.0,
+              "start": 80,
+              "end": 81
+            },
+            {
+              "label": "111101101001",
+              "score": 1.0,
+              "start": 81,
+              "end": 82
+            },
+            {
+              "label": "1101111111101110",
+              "score": 1.0,
+              "start": 82,
+              "end": 83
+            },
+            {
+              "label": "10101110111110",
+              "score": 1.0,
+              "start": 83,
+              "end": 84
+            },
+            {
+              "label": "1110010",
+              "score": 1.0,
+              "start": 84,
+              "end": 85
+            },
+            {
+              "label": "11100000",
+              "score": 1.0,
+              "start": 85,
+              "end": 86
+            },
+            {
+              "label": "101001010",
+              "score": 1.0,
+              "start": 86,
+              "end": 87
+            },
+            {
+              "label": "010110111110",
+              "score": 1.0,
+              "start": 87,
+              "end": 88
+            },
+            {
+              "label": "110111111111111",
+              "score": 1.0,
+              "start": 88,
+              "end": 89
+            },
+            {
+              "label": "011011001",
+              "score": 1.0,
+              "start": 89,
+              "end": 90
+            },
+            {
+              "label": "1101111101000",
+              "score": 1.0,
+              "start": 90,
+              "end": 91
+            },
+            {
+              "label": "00",
+              "score": 1.0,
+              "start": 91,
+              "end": 92
+            },
+            {
+              "label": "11101011111",
+              "score": 1.0,
+              "start": 92,
+              "end": 93
+            },
+            {
+              "label": "0111101111010",
+              "score": 1.0,
+              "start": 93,
+              "end": 94
+            },
+            {
+              "label": "011011000",
+              "score": 1.0,
+              "start": 93,
+              "end": 94
+            },
+            {
+              "label": "110010",
+              "score": 1.0,
+              "start": 94,
+              "end": 95
+            },
+            {
+              "label": "10100011110",
+              "score": 1.0,
+              "start": 95,
+              "end": 96
+            },
+            {
+              "label": "011110101",
+              "score": 1.0,
+              "start": 96,
+              "end": 97
+            },
+            {
+              "label": "011100",
+              "score": 1.0,
+              "start": 97,
+              "end": 98
+            },
+            {
+              "label": "111101001101",
+              "score": 1.0,
+              "start": 97,
+              "end": 98
+            },
+            {
+              "label": "0111110",
+              "score": 1.0,
+              "start": 98,
+              "end": 99
+            },
+            {
+              "label": "1111011011000",
+              "score": 1.0,
+              "start": 99,
+              "end": 100
+            },
+            {
+              "label": "111000110110",
+              "score": 1.0,
+              "start": 100,
+              "end": 101
+            },
+            {
+              "label": "01101111010",
+              "score": 1.0,
+              "start": 101,
+              "end": 102
+            },
+            {
+              "label": "110010",
+              "score": 1.0,
+              "start": 102,
+              "end": 103
+            },
+            {
+              "label": "011010100",
+              "score": 1.0,
+              "start": 103,
+              "end": 104
+            },
+            {
+              "label": "11101110111110",
+              "score": 1.0,
+              "start": 103,
+              "end": 104
+            },
+            {
+              "label": "0110111110111",
+              "score": 1.0,
+              "start": 104,
+              "end": 105
+            },
+            {
+              "label": "0111110",
+              "score": 1.0,
+              "start": 105,
+              "end": 106
+            },
+            {
+              "label": "0111111101",
+              "score": 1.0,
+              "start": 106,
+              "end": 107
+            },
+            {
+              "label": "01111001100",
+              "score": 1.0,
+              "start": 107,
+              "end": 108
+            },
+            {
+              "label": "01101111010",
+              "score": 1.0,
+              "start": 108,
+              "end": 109
+            },
+            {
+              "label": "111010010",
+              "score": 1.0,
+              "start": 109,
+              "end": 110
+            },
+            {
+              "label": "0110111110111",
+              "score": 1.0,
+              "start": 110,
+              "end": 111
+            },
+            {
+              "label": "1110100111",
+              "score": 1.0,
+              "start": 111,
+              "end": 112
+            },
+            {
+              "label": "0111111111111",
+              "score": 1.0,
+              "start": 112,
+              "end": 113
+            },
+            {
+              "label": "1111011011000",
+              "score": 1.0,
+              "start": 113,
+              "end": 114
+            },
+            {
+              "label": "1110010",
+              "score": 1.0,
+              "start": 114,
+              "end": 115
+            },
+            {
+              "label": "11101010",
+              "score": 1.0,
+              "start": 115,
+              "end": 116
+            },
+            {
+              "label": "011100",
+              "score": 1.0,
+              "start": 116,
+              "end": 117
+            },
+            {
+              "label": "111101001101",
+              "score": 1.0,
+              "start": 116,
+              "end": 117
+            },
+            {
+              "label": "00",
+              "score": 1.0,
+              "start": 117,
+              "end": 118
+            },
+            {
+              "label": "1110101110",
+              "score": 1.0,
+              "start": 118,
+              "end": 119
+            },
+            {
+              "label": "1111101011",
+              "score": 1.0,
+              "start": 118,
+              "end": 119
+            },
+            {
+              "label": "011101",
+              "score": 1.0,
+              "start": 119,
+              "end": 120
+            },
+            {
+              "label": "01111000",
+              "score": 1.0,
+              "start": 120,
+              "end": 121
+            },
+            {
+              "label": "1111011000111",
+              "score": 1.0,
+              "start": 121,
+              "end": 122
+            },
+            {
+              "label": "101001010",
+              "score": 1.0,
+              "start": 122,
+              "end": 123
+            },
+            {
+              "label": "11110101001100",
+              "score": 1.0,
+              "start": 123,
+              "end": 124
+            },
+            {
+              "label": "0111111101",
+              "score": 1.0,
+              "start": 124,
+              "end": 125
+            },
+            {
+              "label": "111101010100",
+              "score": 1.0,
+              "start": 125,
+              "end": 126
+            },
+            {
+              "label": "110010",
+              "score": 1.0,
+              "start": 126,
+              "end": 127
+            },
+            {
+              "label": "101111101111",
+              "score": 1.0,
+              "start": 127,
+              "end": 128
+            },
+            {
+              "label": "0100",
+              "score": 1.0,
+              "start": 128,
+              "end": 129
+            },
+            {
+              "label": "11101010",
+              "score": 1.0,
+              "start": 129,
+              "end": 130
+            },
+            {
+              "label": "1110010",
+              "score": 1.0,
+              "start": 130,
+              "end": 131
+            },
+            {
+              "label": "01111011100",
+              "score": 1.0,
+              "start": 131,
+              "end": 132
+            },
+            {
+              "label": "1110100010",
+              "score": 1.0,
+              "start": 132,
+              "end": 133
+            },
+            {
+              "label": "011011001",
+              "score": 1.0,
+              "start": 133,
+              "end": 134
+            },
+            {
+              "label": "11110111001100",
+              "score": 1.0,
+              "start": 134,
+              "end": 135
+            },
+            {
+              "label": "10101110000",
+              "score": 1.0,
+              "start": 135,
+              "end": 136
+            },
+            {
+              "label": "01100",
+              "score": 1.0,
+              "start": 135,
+              "end": 136
+            },
+            {
+              "label": "111100001001",
+              "score": 1.0,
+              "start": 136,
+              "end": 137
+            },
+            {
+              "label": "110010",
+              "score": 1.0,
+              "start": 137,
+              "end": 138
+            },
+            {
+              "label": "10110111000",
+              "score": 1.0,
+              "start": 138,
+              "end": 139
+            },
+            {
+              "label": "111101010011101",
+              "score": 1.0,
+              "start": 139,
+              "end": 140
+            },
+            {
+              "label": "00",
+              "score": 1.0,
+              "start": 140,
+              "end": 141
+            },
+            {
+              "label": "1110010",
+              "score": 1.0,
+              "start": 141,
+              "end": 142
+            },
+            {
+              "label": "11101010",
+              "score": 1.0,
+              "start": 142,
+              "end": 143
+            },
+            {
+              "label": "11110101111101",
+              "score": 1.0,
+              "start": 143,
+              "end": 144
+            },
+            {
+              "label": "11110101111001",
+              "score": 1.0,
+              "start": 143,
+              "end": 144
+            },
+            {
+              "label": "0111100111110",
+              "score": 1.0,
+              "start": 144,
+              "end": 145
+            },
+            {
+              "label": "110000",
+              "score": 1.0,
+              "start": 145,
+              "end": 146
+            },
+            {
+              "label": "11100010110",
+              "score": 1.0,
+              "start": 145,
+              "end": 146
+            },
+            {
+              "label": "101111101110",
+              "score": 1.0,
+              "start": 146,
+              "end": 147
+            },
+            {
+              "label": "01010",
+              "score": 1.0,
+              "start": 147,
+              "end": 148
+            },
+            {
+              "label": "11011111010011",
+              "score": 1.0,
+              "start": 147,
+              "end": 148
+            },
+            {
+              "label": "110010",
+              "score": 1.0,
+              "start": 148,
+              "end": 149
+            },
+            {
+              "label": "1110111110110",
+              "score": 1.0,
+              "start": 149,
+              "end": 150
+            },
+            {
+              "label": "00",
+              "score": 1.0,
+              "start": 150,
+              "end": 151
+            },
+            {
+              "label": "11100111",
+              "score": 1.0,
+              "start": 151,
+              "end": 152
+            },
+            {
+              "label": "111011000",
+              "score": 1.0,
+              "start": 151,
+              "end": 152
+            },
+            {
+              "label": "10110111000",
+              "score": 1.0,
+              "start": 152,
+              "end": 153
+            },
+            {
+              "label": "0110101110",
+              "score": 1.0,
+              "start": 153,
+              "end": 154
+            },
+            {
+              "label": "11110001010",
+              "score": 1.0,
+              "start": 154,
+              "end": 155
+            },
+            {
+              "label": "00",
+              "score": 1.0,
+              "start": 155,
+              "end": 156
+            },
+            {
+              "label": "11101010",
+              "score": 1.0,
+              "start": 156,
+              "end": 157
+            },
+            {
+              "label": "011100",
+              "score": 1.0,
+              "start": 157,
+              "end": 158
+            },
+            {
+              "label": "111101001101",
+              "score": 1.0,
+              "start": 157,
+              "end": 158
+            },
+            {
+              "label": "1110100110",
+              "score": 1.0,
+              "start": 158,
+              "end": 159
+            },
+            {
+              "label": "0110111011",
+              "score": 1.0,
+              "start": 159,
+              "end": 160
+            },
+            {
+              "label": "1111001000",
+              "score": 1.0,
+              "start": 160,
+              "end": 161
+            },
+            {
+              "label": "111100110",
+              "score": 1.0,
+              "start": 161,
+              "end": 162
+            },
+            {
+              "label": "1110010",
+              "score": 1.0,
+              "start": 162,
+              "end": 163
+            },
+            {
+              "label": "111101111010110",
+              "score": 1.0,
+              "start": 163,
+              "end": 164
+            },
+            {
+              "label": "1101110101110",
+              "score": 1.0,
+              "start": 164,
+              "end": 165
+            },
+            {
+              "label": "1110010",
+              "score": 1.0,
+              "start": 165,
+              "end": 166
+            },
+            {
+              "label": "0110111111010",
+              "score": 1.0,
+              "start": 166,
+              "end": 167
+            },
+            {
+              "label": "010110110",
+              "score": 1.0,
+              "start": 167,
+              "end": 168
+            },
+            {
+              "label": "101001010",
+              "score": 1.0,
+              "start": 168,
+              "end": 169
+            },
+            {
+              "label": "1010011000",
+              "score": 1.0,
+              "start": 169,
+              "end": 170
+            },
+            {
+              "label": "11110111111110",
+              "score": 1.0,
+              "start": 169,
+              "end": 170
+            },
+            {
+              "label": "00",
+              "score": 1.0,
+              "start": 170,
+              "end": 171
+            },
+            {
+              "label": "1110101110",
+              "score": 1.0,
+              "start": 171,
+              "end": 172
+            },
+            {
+              "label": "1111101011",
+              "score": 1.0,
+              "start": 171,
+              "end": 172
+            },
+            {
+              "label": "011100",
+              "score": 1.0,
+              "start": 172,
+              "end": 173
+            },
+            {
+              "label": "111101001101",
+              "score": 1.0,
+              "start": 172,
+              "end": 173
+            },
+            {
+              "label": "01111011011111",
+              "score": 1.0,
+              "start": 173,
+              "end": 174
+            },
+            {
+              "label": "1110010",
+              "score": 1.0,
+              "start": 174,
+              "end": 175
+            },
+            {
+              "label": "1101110101111",
+              "score": 1.0,
+              "start": 175,
+              "end": 176
+            },
+            {
+              "label": "1110010",
+              "score": 1.0,
+              "start": 176,
+              "end": 177
+            },
+            {
+              "label": "1010011110",
+              "score": 1.0,
+              "start": 177,
+              "end": 178
+            },
+            {
+              "label": "0100",
+              "score": 1.0,
+              "start": 178,
+              "end": 179
+            },
+            {
+              "label": "110010",
+              "score": 1.0,
+              "start": 179,
+              "end": 180
+            },
+            {
+              "label": "10111110000",
+              "score": 1.0,
+              "start": 180,
+              "end": 181
+            },
+            {
+              "label": "1110111100011",
+              "score": 1.0,
+              "start": 180,
+              "end": 181
+            },
+            {
+              "label": "011011100",
+              "score": 1.0,
+              "start": 181,
+              "end": 182
+            },
+            {
+              "label": "111100110",
+              "score": 1.0,
+              "start": 182,
+              "end": 183
+            },
+            {
+              "label": "111101111011110",
+              "score": 1.0,
+              "start": 183,
+              "end": 184
+            },
+            {
+              "label": "1101110110010",
+              "score": 1.0,
+              "start": 184,
+              "end": 185
+            },
+            {
+              "label": "0100",
+              "score": 1.0,
+              "start": 185,
+              "end": 186
+            },
+            {
+              "label": "111011000",
+              "score": 1.0,
+              "start": 186,
+              "end": 187
+            },
+            {
+              "label": "0111110",
+              "score": 1.0,
+              "start": 187,
+              "end": 188
+            },
+            {
+              "label": "110110101111",
+              "score": 1.0,
+              "start": 188,
+              "end": 189
+            },
+            {
+              "label": "101111101000",
+              "score": 1.0,
+              "start": 189,
+              "end": 190
+            },
+            {
+              "label": "0110111011",
+              "score": 1.0,
+              "start": 190,
+              "end": 191
+            },
+            {
+              "label": "111100110",
+              "score": 1.0,
+              "start": 191,
+              "end": 192
+            },
+            {
+              "label": "01111011110111",
+              "score": 1.0,
+              "start": 192,
+              "end": 193
+            },
+            {
+              "label": "111101101110110",
+              "score": 1.0,
+              "start": 193,
+              "end": 194
+            },
+            {
+              "label": "0111111100",
+              "score": 1.0,
+              "start": 194,
+              "end": 195
+            },
+            {
+              "label": "1110010",
+              "score": 1.0,
+              "start": 194,
+              "end": 195
+            },
+            {
+              "label": "1101110110111",
+              "score": 1.0,
+              "start": 195,
+              "end": 196
+            },
+            {
+              "label": "0100",
+              "score": 1.0,
+              "start": 196,
+              "end": 197
+            },
+            {
+              "label": "11110111111011",
+              "score": 1.0,
+              "start": 197,
+              "end": 198
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "viewName": "CLAUSES_STANFORD",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.SpanLabelView",
+          "viewName": "CLAUSES_STANFORD",
+          "generator": "From PARSE_STANFORD",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 0,
+              "end": 53
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 5,
+              "end": 17
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 11,
+              "end": 17
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 27,
+              "end": 52
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 28,
+              "end": 52
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 31,
+              "end": 50
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 53,
+              "end": 67
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 67,
+              "end": 92
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 67,
+              "end": 68
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 69,
+              "end": 91
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 84,
+              "end": 91
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 92,
+              "end": 118
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 92,
+              "end": 114
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 92,
+              "end": 98
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 96,
+              "end": 98
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 97,
+              "end": 98
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 101,
+              "end": 112
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 102,
+              "end": 112
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 102,
+              "end": 105
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 107,
+              "end": 112
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 108,
+              "end": 112
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 109,
+              "end": 112
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 118,
+              "end": 142
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 120,
+              "end": 140
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 121,
+              "end": 140
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 131,
+              "end": 140
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 132,
+              "end": 140
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 135,
+              "end": 140
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 137,
+              "end": 140
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 142,
+              "end": 156
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 144,
+              "end": 155
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 145,
+              "end": 155
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 156,
+              "end": 171
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 158,
+              "end": 170
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 171,
+              "end": 199
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 171,
+              "end": 187
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 173,
+              "end": 187
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 174,
+              "end": 187
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "viewName": "CURRENCY_INDICATOR",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.SpanLabelView",
+          "viewName": "CURRENCY_INDICATOR",
+          "generator": "Gazetteer",
+          "score": 1.0
+        }
+      ]
+    },
+    {
+      "viewName": "DEPENDENCY",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.TreeView",
+          "viewName": "DEPENDENCY",
+          "generator": "DEPENDENCY-annotator",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "ROOT",
+              "start": 18,
+              "end": 19
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 0,
+              "end": 1
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 1,
+              "end": 2
+            },
+            {
+              "label": "COORD",
+              "score": 1.0,
+              "start": 97,
+              "end": 98
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 96,
+              "end": 97
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 98,
+              "end": 99
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 101,
+              "end": 102
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 103,
+              "end": 104
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 102,
+              "end": 103
+            },
+            {
+              "label": "VC",
+              "score": 1.0,
+              "start": 104,
+              "end": 105
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 100,
+              "end": 101
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 105,
+              "end": 106
+            },
+            {
+              "label": "COORD",
+              "score": 1.0,
+              "start": 106,
+              "end": 107
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 141,
+              "end": 142
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 108,
+              "end": 109
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 109,
+              "end": 110
+            },
+            {
+              "label": "VC",
+              "score": 1.0,
+              "start": 110,
+              "end": 111
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 111,
+              "end": 112
+            },
+            {
+              "label": "TMP",
+              "score": 1.0,
+              "start": 107,
+              "end": 108
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 140,
+              "end": 141
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 77,
+              "end": 78
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 76,
+              "end": 77
+            },
+            {
+              "label": "VC",
+              "score": 1.0,
+              "start": 78,
+              "end": 79
+            },
+            {
+              "label": "ADV",
+              "score": 1.0,
+              "start": 79,
+              "end": 80
+            },
+            {
+              "label": "PMOD",
+              "score": 1.0,
+              "start": 83,
+              "end": 84
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 81,
+              "end": 82
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 82,
+              "end": 83
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 80,
+              "end": 81
+            },
+            {
+              "label": "TMP",
+              "score": 1.0,
+              "start": 87,
+              "end": 88
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 66,
+              "end": 67
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 99,
+              "end": 100
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 68,
+              "end": 69
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 11,
+              "end": 12
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 6,
+              "end": 7
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 4,
+              "end": 5
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 2,
+              "end": 3
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 3,
+              "end": 4
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 5,
+              "end": 6
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 7,
+              "end": 8
+            },
+            {
+              "label": "PMOD",
+              "score": 1.0,
+              "start": 10,
+              "end": 11
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 8,
+              "end": 9
+            },
+            {
+              "label": "NAME",
+              "score": 1.0,
+              "start": 9,
+              "end": 10
+            },
+            {
+              "label": "OPRD",
+              "score": 1.0,
+              "start": 12,
+              "end": 13
+            },
+            {
+              "label": "LOC",
+              "score": 1.0,
+              "start": 14,
+              "end": 15
+            },
+            {
+              "label": "PMOD",
+              "score": 1.0,
+              "start": 16,
+              "end": 17
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 15,
+              "end": 16
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 13,
+              "end": 14
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 75,
+              "end": 76
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 17,
+              "end": 18
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 113,
+              "end": 114
+            },
+            {
+              "label": "TMP",
+              "score": 1.0,
+              "start": 19,
+              "end": 20
+            },
+            {
+              "label": "LOC",
+              "score": 1.0,
+              "start": 20,
+              "end": 21
+            },
+            {
+              "label": "PMOD",
+              "score": 1.0,
+              "start": 21,
+              "end": 22
+            },
+            {
+              "label": "SUFFIX",
+              "score": 1.0,
+              "start": 22,
+              "end": 23
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 52,
+              "end": 53
+            },
+            {
+              "label": "COORD",
+              "score": 1.0,
+              "start": 116,
+              "end": 117
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 114,
+              "end": 115
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 115,
+              "end": 116
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 84,
+              "end": 85
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 56,
+              "end": 57
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 112,
+              "end": 113
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 55,
+              "end": 56
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 53,
+              "end": 54
+            },
+            {
+              "label": "SUFFIX",
+              "score": 1.0,
+              "start": 54,
+              "end": 55
+            },
+            {
+              "label": "VC",
+              "score": 1.0,
+              "start": 57,
+              "end": 58
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 59,
+              "end": 60
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 58,
+              "end": 59
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 60,
+              "end": 61
+            },
+            {
+              "label": "PMOD",
+              "score": 1.0,
+              "start": 63,
+              "end": 64
+            },
+            {
+              "label": "COORD",
+              "score": 1.0,
+              "start": 64,
+              "end": 65
+            },
+            {
+              "label": "CONJ",
+              "score": 1.0,
+              "start": 65,
+              "end": 66
+            },
+            {
+              "label": "APPO",
+              "score": 1.0,
+              "start": 67,
+              "end": 68
+            },
+            {
+              "label": "OPRD",
+              "score": 1.0,
+              "start": 71,
+              "end": 72
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 69,
+              "end": 70
+            },
+            {
+              "label": "SUFFIX",
+              "score": 1.0,
+              "start": 70,
+              "end": 71
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 72,
+              "end": 73
+            },
+            {
+              "label": "PMOD",
+              "score": 1.0,
+              "start": 73,
+              "end": 74
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 61,
+              "end": 62
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 62,
+              "end": 63
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 89,
+              "end": 90
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 88,
+              "end": 89
+            },
+            {
+              "label": "PRD",
+              "score": 1.0,
+              "start": 90,
+              "end": 91
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 170,
+              "end": 171
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 155,
+              "end": 156
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 117,
+              "end": 118
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 27,
+              "end": 28
+            },
+            {
+              "label": "SUB",
+              "score": 1.0,
+              "start": 34,
+              "end": 35
+            },
+            {
+              "label": "ADV",
+              "score": 1.0,
+              "start": 35,
+              "end": 36
+            },
+            {
+              "label": "VC",
+              "score": 1.0,
+              "start": 36,
+              "end": 37
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 38,
+              "end": 39
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 37,
+              "end": 38
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 39,
+              "end": 40
+            },
+            {
+              "label": "PMOD",
+              "score": 1.0,
+              "start": 43,
+              "end": 44
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 41,
+              "end": 42
+            },
+            {
+              "label": "TITLE",
+              "score": 1.0,
+              "start": 40,
+              "end": 41
+            },
+            {
+              "label": "SUFFIX",
+              "score": 1.0,
+              "start": 42,
+              "end": 43
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 44,
+              "end": 45
+            },
+            {
+              "label": "IM",
+              "score": 1.0,
+              "start": 45,
+              "end": 46
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 49,
+              "end": 50
+            },
+            {
+              "label": "NAME",
+              "score": 1.0,
+              "start": 48,
+              "end": 49
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 47,
+              "end": 48
+            },
+            {
+              "label": "NAME",
+              "score": 1.0,
+              "start": 46,
+              "end": 47
+            },
+            {
+              "label": "TMP",
+              "score": 1.0,
+              "start": 51,
+              "end": 52
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 50,
+              "end": 51
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 25,
+              "end": 26
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 23,
+              "end": 24
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 24,
+              "end": 25
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 26,
+              "end": 27
+            },
+            {
+              "label": "SUB",
+              "score": 1.0,
+              "start": 29,
+              "end": 30
+            },
+            {
+              "label": "PRD",
+              "score": 1.0,
+              "start": 31,
+              "end": 32
+            },
+            {
+              "label": "LOC",
+              "score": 1.0,
+              "start": 32,
+              "end": 33
+            },
+            {
+              "label": "PMOD",
+              "score": 1.0,
+              "start": 33,
+              "end": 34
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 74,
+              "end": 75
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 28,
+              "end": 29
+            },
+            {
+              "label": "PRD",
+              "score": 1.0,
+              "start": 30,
+              "end": 31
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 91,
+              "end": 92
+            },
+            {
+              "label": "COORD",
+              "score": 1.0,
+              "start": 157,
+              "end": 158
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 159,
+              "end": 160
+            },
+            {
+              "label": "ADV",
+              "score": 1.0,
+              "start": 160,
+              "end": 161
+            },
+            {
+              "label": "VC",
+              "score": 1.0,
+              "start": 161,
+              "end": 162
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 162,
+              "end": 163
+            },
+            {
+              "label": "PRD",
+              "score": 1.0,
+              "start": 163,
+              "end": 164
+            },
+            {
+              "label": "APPO",
+              "score": 1.0,
+              "start": 164,
+              "end": 165
+            },
+            {
+              "label": "TMP",
+              "score": 1.0,
+              "start": 166,
+              "end": 167
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 158,
+              "end": 159
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 130,
+              "end": 131
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 198,
+              "end": 199
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 119,
+              "end": 120
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 165,
+              "end": 166
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 118,
+              "end": 119
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 120,
+              "end": 121
+            },
+            {
+              "label": "SUB",
+              "score": 1.0,
+              "start": 190,
+              "end": 191
+            },
+            {
+              "label": "VC",
+              "score": 1.0,
+              "start": 191,
+              "end": 192
+            },
+            {
+              "label": "COORD",
+              "score": 1.0,
+              "start": 192,
+              "end": 193
+            },
+            {
+              "label": "PRD",
+              "score": 1.0,
+              "start": 193,
+              "end": 194
+            },
+            {
+              "label": "COORD",
+              "score": 1.0,
+              "start": 194,
+              "end": 195
+            },
+            {
+              "label": "CONJ",
+              "score": 1.0,
+              "start": 195,
+              "end": 196
+            },
+            {
+              "label": "AMOD",
+              "score": 1.0,
+              "start": 196,
+              "end": 197
+            },
+            {
+              "label": "PMOD",
+              "score": 1.0,
+              "start": 197,
+              "end": 198
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 187,
+              "end": 188
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 189,
+              "end": 190
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 188,
+              "end": 189
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 122,
+              "end": 123
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 121,
+              "end": 122
+            },
+            {
+              "label": "APPO",
+              "score": 1.0,
+              "start": 123,
+              "end": 124
+            },
+            {
+              "label": "COORD",
+              "score": 1.0,
+              "start": 124,
+              "end": 125
+            },
+            {
+              "label": "CONJ",
+              "score": 1.0,
+              "start": 125,
+              "end": 126
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 127,
+              "end": 128
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 128,
+              "end": 129
+            },
+            {
+              "label": "PMOD",
+              "score": 1.0,
+              "start": 129,
+              "end": 130
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 126,
+              "end": 127
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 131,
+              "end": 132
+            },
+            {
+              "label": "SUB",
+              "score": 1.0,
+              "start": 133,
+              "end": 134
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 132,
+              "end": 133
+            },
+            {
+              "label": "PRD",
+              "score": 1.0,
+              "start": 134,
+              "end": 135
+            },
+            {
+              "label": "AMOD",
+              "score": 1.0,
+              "start": 135,
+              "end": 136
+            },
+            {
+              "label": "IM",
+              "score": 1.0,
+              "start": 136,
+              "end": 137
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 138,
+              "end": 139
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 137,
+              "end": 138
+            },
+            {
+              "label": "SUB",
+              "score": 1.0,
+              "start": 139,
+              "end": 140
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 156,
+              "end": 157
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 93,
+              "end": 94
+            },
+            {
+              "label": "PRD",
+              "score": 1.0,
+              "start": 95,
+              "end": 96
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 167,
+              "end": 168
+            },
+            {
+              "label": "PMOD",
+              "score": 1.0,
+              "start": 168,
+              "end": 169
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 172,
+              "end": 173
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 143,
+              "end": 144
+            },
+            {
+              "label": "TMP",
+              "score": 1.0,
+              "start": 144,
+              "end": 145
+            },
+            {
+              "label": "PMOD",
+              "score": 1.0,
+              "start": 146,
+              "end": 147
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 145,
+              "end": 146
+            },
+            {
+              "label": "LOC",
+              "score": 1.0,
+              "start": 147,
+              "end": 148
+            },
+            {
+              "label": "PMOD",
+              "score": 1.0,
+              "start": 149,
+              "end": 150
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 150,
+              "end": 151
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 142,
+              "end": 143
+            },
+            {
+              "label": "OBJ",
+              "score": 1.0,
+              "start": 153,
+              "end": 154
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 152,
+              "end": 153
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 148,
+              "end": 149
+            },
+            {
+              "label": "NAME",
+              "score": 1.0,
+              "start": 151,
+              "end": 152
+            },
+            {
+              "label": "VC",
+              "score": 1.0,
+              "start": 154,
+              "end": 155
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 171,
+              "end": 172
+            },
+            {
+              "label": "TMP",
+              "score": 1.0,
+              "start": 173,
+              "end": 174
+            },
+            {
+              "label": "SUB",
+              "score": 1.0,
+              "start": 181,
+              "end": 182
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 177,
+              "end": 178
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 175,
+              "end": 176
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 176,
+              "end": 177
+            },
+            {
+              "label": "P",
+              "score": 1.0,
+              "start": 174,
+              "end": 175
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 178,
+              "end": 179
+            },
+            {
+              "label": "PMOD",
+              "score": 1.0,
+              "start": 180,
+              "end": 181
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 179,
+              "end": 180
+            },
+            {
+              "label": "VC",
+              "score": 1.0,
+              "start": 182,
+              "end": 183
+            },
+            {
+              "label": "PRD",
+              "score": 1.0,
+              "start": 184,
+              "end": 185
+            },
+            {
+              "label": "AMOD",
+              "score": 1.0,
+              "start": 183,
+              "end": 184
+            },
+            {
+              "label": "AMOD",
+              "score": 1.0,
+              "start": 185,
+              "end": 186
+            },
+            {
+              "label": "PMOD",
+              "score": 1.0,
+              "start": 186,
+              "end": 187
+            },
+            {
+              "label": "PMOD",
+              "score": 1.0,
+              "start": 169,
+              "end": 170
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 94,
+              "end": 95
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 86,
+              "end": 87
+            },
+            {
+              "label": "NMOD",
+              "score": 1.0,
+              "start": 85,
+              "end": 86
+            },
+            {
+              "label": "SBJ",
+              "score": 1.0,
+              "start": 92,
+              "end": 93
+            }
+          ],
+          "relations": [
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 1
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 1,
+              "targetConstituent": 2
+            },
+            {
+              "relationName": "COORD",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 3
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 3,
+              "targetConstituent": 4
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 3,
+              "targetConstituent": 5
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 3,
+              "targetConstituent": 6
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 6,
+              "targetConstituent": 7
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 7,
+              "targetConstituent": 8
+            },
+            {
+              "relationName": "VC",
+              "score": 1.0,
+              "srcConstituent": 6,
+              "targetConstituent": 9
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 9,
+              "targetConstituent": 10
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 9,
+              "targetConstituent": 11
+            },
+            {
+              "relationName": "COORD",
+              "score": 1.0,
+              "srcConstituent": 9,
+              "targetConstituent": 12
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 9,
+              "targetConstituent": 13
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 3,
+              "targetConstituent": 14
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 14,
+              "targetConstituent": 15
+            },
+            {
+              "relationName": "VC",
+              "score": 1.0,
+              "srcConstituent": 14,
+              "targetConstituent": 16
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 16,
+              "targetConstituent": 17
+            },
+            {
+              "relationName": "TMP",
+              "score": 1.0,
+              "srcConstituent": 16,
+              "targetConstituent": 18
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 3,
+              "targetConstituent": 19
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 3,
+              "targetConstituent": 20
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 20,
+              "targetConstituent": 21
+            },
+            {
+              "relationName": "VC",
+              "score": 1.0,
+              "srcConstituent": 20,
+              "targetConstituent": 22
+            },
+            {
+              "relationName": "ADV",
+              "score": 1.0,
+              "srcConstituent": 22,
+              "targetConstituent": 23
+            },
+            {
+              "relationName": "PMOD",
+              "score": 1.0,
+              "srcConstituent": 23,
+              "targetConstituent": 24
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 24,
+              "targetConstituent": 25
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 24,
+              "targetConstituent": 26
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 26,
+              "targetConstituent": 27
+            },
+            {
+              "relationName": "TMP",
+              "score": 1.0,
+              "srcConstituent": 22,
+              "targetConstituent": 28
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 29
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 30
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 31
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 32
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 32,
+              "targetConstituent": 33
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 33,
+              "targetConstituent": 34
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 34,
+              "targetConstituent": 35
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 34,
+              "targetConstituent": 36
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 33,
+              "targetConstituent": 37
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 33,
+              "targetConstituent": 38
+            },
+            {
+              "relationName": "PMOD",
+              "score": 1.0,
+              "srcConstituent": 38,
+              "targetConstituent": 39
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 39,
+              "targetConstituent": 40
+            },
+            {
+              "relationName": "NAME",
+              "score": 1.0,
+              "srcConstituent": 39,
+              "targetConstituent": 41
+            },
+            {
+              "relationName": "OPRD",
+              "score": 1.0,
+              "srcConstituent": 32,
+              "targetConstituent": 42
+            },
+            {
+              "relationName": "LOC",
+              "score": 1.0,
+              "srcConstituent": 42,
+              "targetConstituent": 43
+            },
+            {
+              "relationName": "PMOD",
+              "score": 1.0,
+              "srcConstituent": 43,
+              "targetConstituent": 44
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 44,
+              "targetConstituent": 45
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 32,
+              "targetConstituent": 46
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 47
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 48
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 49
+            },
+            {
+              "relationName": "TMP",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 50
+            },
+            {
+              "relationName": "LOC",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 51
+            },
+            {
+              "relationName": "PMOD",
+              "score": 1.0,
+              "srcConstituent": 51,
+              "targetConstituent": 52
+            },
+            {
+              "relationName": "SUFFIX",
+              "score": 1.0,
+              "srcConstituent": 52,
+              "targetConstituent": 53
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 54
+            },
+            {
+              "relationName": "COORD",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 55
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 55,
+              "targetConstituent": 56
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 55,
+              "targetConstituent": 57
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 55,
+              "targetConstituent": 58
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 55,
+              "targetConstituent": 59
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 59,
+              "targetConstituent": 60
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 59,
+              "targetConstituent": 61
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 61,
+              "targetConstituent": 62
+            },
+            {
+              "relationName": "SUFFIX",
+              "score": 1.0,
+              "srcConstituent": 62,
+              "targetConstituent": 63
+            },
+            {
+              "relationName": "VC",
+              "score": 1.0,
+              "srcConstituent": 59,
+              "targetConstituent": 64
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 64,
+              "targetConstituent": 65
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 65,
+              "targetConstituent": 66
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 65,
+              "targetConstituent": 67
+            },
+            {
+              "relationName": "PMOD",
+              "score": 1.0,
+              "srcConstituent": 67,
+              "targetConstituent": 68
+            },
+            {
+              "relationName": "COORD",
+              "score": 1.0,
+              "srcConstituent": 68,
+              "targetConstituent": 69
+            },
+            {
+              "relationName": "CONJ",
+              "score": 1.0,
+              "srcConstituent": 69,
+              "targetConstituent": 70
+            },
+            {
+              "relationName": "APPO",
+              "score": 1.0,
+              "srcConstituent": 68,
+              "targetConstituent": 71
+            },
+            {
+              "relationName": "OPRD",
+              "score": 1.0,
+              "srcConstituent": 71,
+              "targetConstituent": 72
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 72,
+              "targetConstituent": 73
+            },
+            {
+              "relationName": "SUFFIX",
+              "score": 1.0,
+              "srcConstituent": 73,
+              "targetConstituent": 74
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 72,
+              "targetConstituent": 75
+            },
+            {
+              "relationName": "PMOD",
+              "score": 1.0,
+              "srcConstituent": 75,
+              "targetConstituent": 76
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 68,
+              "targetConstituent": 77
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 68,
+              "targetConstituent": 78
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 55,
+              "targetConstituent": 79
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 79,
+              "targetConstituent": 80
+            },
+            {
+              "relationName": "PRD",
+              "score": 1.0,
+              "srcConstituent": 79,
+              "targetConstituent": 81
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 55,
+              "targetConstituent": 82
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 55,
+              "targetConstituent": 83
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 84
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 85
+            },
+            {
+              "relationName": "SUB",
+              "score": 1.0,
+              "srcConstituent": 85,
+              "targetConstituent": 86
+            },
+            {
+              "relationName": "ADV",
+              "score": 1.0,
+              "srcConstituent": 86,
+              "targetConstituent": 87
+            },
+            {
+              "relationName": "VC",
+              "score": 1.0,
+              "srcConstituent": 86,
+              "targetConstituent": 88
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 88,
+              "targetConstituent": 89
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 89,
+              "targetConstituent": 90
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 89,
+              "targetConstituent": 91
+            },
+            {
+              "relationName": "PMOD",
+              "score": 1.0,
+              "srcConstituent": 91,
+              "targetConstituent": 92
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 92,
+              "targetConstituent": 93
+            },
+            {
+              "relationName": "TITLE",
+              "score": 1.0,
+              "srcConstituent": 93,
+              "targetConstituent": 94
+            },
+            {
+              "relationName": "SUFFIX",
+              "score": 1.0,
+              "srcConstituent": 93,
+              "targetConstituent": 95
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 92,
+              "targetConstituent": 96
+            },
+            {
+              "relationName": "IM",
+              "score": 1.0,
+              "srcConstituent": 96,
+              "targetConstituent": 97
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 97,
+              "targetConstituent": 98
+            },
+            {
+              "relationName": "NAME",
+              "score": 1.0,
+              "srcConstituent": 98,
+              "targetConstituent": 99
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 99,
+              "targetConstituent": 100
+            },
+            {
+              "relationName": "NAME",
+              "score": 1.0,
+              "srcConstituent": 100,
+              "targetConstituent": 101
+            },
+            {
+              "relationName": "TMP",
+              "score": 1.0,
+              "srcConstituent": 97,
+              "targetConstituent": 102
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 102,
+              "targetConstituent": 103
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 86,
+              "targetConstituent": 104
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 104,
+              "targetConstituent": 105
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 104,
+              "targetConstituent": 106
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 104,
+              "targetConstituent": 107
+            },
+            {
+              "relationName": "SUB",
+              "score": 1.0,
+              "srcConstituent": 85,
+              "targetConstituent": 108
+            },
+            {
+              "relationName": "PRD",
+              "score": 1.0,
+              "srcConstituent": 108,
+              "targetConstituent": 109
+            },
+            {
+              "relationName": "LOC",
+              "score": 1.0,
+              "srcConstituent": 108,
+              "targetConstituent": 110
+            },
+            {
+              "relationName": "PMOD",
+              "score": 1.0,
+              "srcConstituent": 110,
+              "targetConstituent": 111
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 108,
+              "targetConstituent": 112
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 108,
+              "targetConstituent": 113
+            },
+            {
+              "relationName": "PRD",
+              "score": 1.0,
+              "srcConstituent": 108,
+              "targetConstituent": 114
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 115
+            },
+            {
+              "relationName": "COORD",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 116
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 116,
+              "targetConstituent": 117
+            },
+            {
+              "relationName": "ADV",
+              "score": 1.0,
+              "srcConstituent": 117,
+              "targetConstituent": 118
+            },
+            {
+              "relationName": "VC",
+              "score": 1.0,
+              "srcConstituent": 117,
+              "targetConstituent": 119
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 119,
+              "targetConstituent": 120
+            },
+            {
+              "relationName": "PRD",
+              "score": 1.0,
+              "srcConstituent": 119,
+              "targetConstituent": 121
+            },
+            {
+              "relationName": "APPO",
+              "score": 1.0,
+              "srcConstituent": 121,
+              "targetConstituent": 122
+            },
+            {
+              "relationName": "TMP",
+              "score": 1.0,
+              "srcConstituent": 119,
+              "targetConstituent": 123
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 117,
+              "targetConstituent": 124
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 116,
+              "targetConstituent": 125
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 116,
+              "targetConstituent": 126
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 116,
+              "targetConstituent": 127
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 127,
+              "targetConstituent": 128
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 127,
+              "targetConstituent": 129
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 127,
+              "targetConstituent": 130
+            },
+            {
+              "relationName": "SUB",
+              "score": 1.0,
+              "srcConstituent": 130,
+              "targetConstituent": 131
+            },
+            {
+              "relationName": "VC",
+              "score": 1.0,
+              "srcConstituent": 131,
+              "targetConstituent": 132
+            },
+            {
+              "relationName": "COORD",
+              "score": 1.0,
+              "srcConstituent": 132,
+              "targetConstituent": 133
+            },
+            {
+              "relationName": "PRD",
+              "score": 1.0,
+              "srcConstituent": 132,
+              "targetConstituent": 134
+            },
+            {
+              "relationName": "COORD",
+              "score": 1.0,
+              "srcConstituent": 134,
+              "targetConstituent": 135
+            },
+            {
+              "relationName": "CONJ",
+              "score": 1.0,
+              "srcConstituent": 135,
+              "targetConstituent": 136
+            },
+            {
+              "relationName": "AMOD",
+              "score": 1.0,
+              "srcConstituent": 136,
+              "targetConstituent": 137
+            },
+            {
+              "relationName": "PMOD",
+              "score": 1.0,
+              "srcConstituent": 137,
+              "targetConstituent": 138
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 131,
+              "targetConstituent": 139
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 131,
+              "targetConstituent": 140
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 140,
+              "targetConstituent": 141
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 127,
+              "targetConstituent": 142
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 142,
+              "targetConstituent": 143
+            },
+            {
+              "relationName": "APPO",
+              "score": 1.0,
+              "srcConstituent": 143,
+              "targetConstituent": 144
+            },
+            {
+              "relationName": "COORD",
+              "score": 1.0,
+              "srcConstituent": 144,
+              "targetConstituent": 145
+            },
+            {
+              "relationName": "CONJ",
+              "score": 1.0,
+              "srcConstituent": 145,
+              "targetConstituent": 146
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 146,
+              "targetConstituent": 147
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 147,
+              "targetConstituent": 148
+            },
+            {
+              "relationName": "PMOD",
+              "score": 1.0,
+              "srcConstituent": 148,
+              "targetConstituent": 149
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 147,
+              "targetConstituent": 150
+            },
+            {
+              "relationName": "PRP",
+              "score": 1.0,
+              "srcConstituent": 146,
+              "targetConstituent": 151
+            },
+            {
+              "relationName": "SUB",
+              "score": 1.0,
+              "srcConstituent": 151,
+              "targetConstituent": 152
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 152,
+              "targetConstituent": 153
+            },
+            {
+              "relationName": "PRD",
+              "score": 1.0,
+              "srcConstituent": 152,
+              "targetConstituent": 154
+            },
+            {
+              "relationName": "AMOD",
+              "score": 1.0,
+              "srcConstituent": 154,
+              "targetConstituent": 155
+            },
+            {
+              "relationName": "IM",
+              "score": 1.0,
+              "srcConstituent": 155,
+              "targetConstituent": 156
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 156,
+              "targetConstituent": 157
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 157,
+              "targetConstituent": 158
+            },
+            {
+              "relationName": "SUB",
+              "score": 1.0,
+              "srcConstituent": 151,
+              "targetConstituent": 159
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 116,
+              "targetConstituent": 160
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 116,
+              "targetConstituent": 161
+            },
+            {
+              "relationName": "PRD",
+              "score": 1.0,
+              "srcConstituent": 161,
+              "targetConstituent": 162
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 162,
+              "targetConstituent": 163
+            },
+            {
+              "relationName": "PMOD",
+              "score": 1.0,
+              "srcConstituent": 163,
+              "targetConstituent": 164
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 164,
+              "targetConstituent": 165
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 165,
+              "targetConstituent": 166
+            },
+            {
+              "relationName": "TMP",
+              "score": 1.0,
+              "srcConstituent": 166,
+              "targetConstituent": 167
+            },
+            {
+              "relationName": "PMOD",
+              "score": 1.0,
+              "srcConstituent": 167,
+              "targetConstituent": 168
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 168,
+              "targetConstituent": 169
+            },
+            {
+              "relationName": "LOC",
+              "score": 1.0,
+              "srcConstituent": 168,
+              "targetConstituent": 170
+            },
+            {
+              "relationName": "PMOD",
+              "score": 1.0,
+              "srcConstituent": 170,
+              "targetConstituent": 171
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 171,
+              "targetConstituent": 172
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 166,
+              "targetConstituent": 173
+            },
+            {
+              "relationName": "OBJ",
+              "score": 1.0,
+              "srcConstituent": 165,
+              "targetConstituent": 174
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 174,
+              "targetConstituent": 175
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 175,
+              "targetConstituent": 176
+            },
+            {
+              "relationName": "NAME",
+              "score": 1.0,
+              "srcConstituent": 175,
+              "targetConstituent": 177
+            },
+            {
+              "relationName": "VC",
+              "score": 1.0,
+              "srcConstituent": 174,
+              "targetConstituent": 178
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 165,
+              "targetConstituent": 179
+            },
+            {
+              "relationName": "TMP",
+              "score": 1.0,
+              "srcConstituent": 165,
+              "targetConstituent": 180
+            },
+            {
+              "relationName": "SUB",
+              "score": 1.0,
+              "srcConstituent": 180,
+              "targetConstituent": 181
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 181,
+              "targetConstituent": 182
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 182,
+              "targetConstituent": 183
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 183,
+              "targetConstituent": 184
+            },
+            {
+              "relationName": "P",
+              "score": 1.0,
+              "srcConstituent": 183,
+              "targetConstituent": 185
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 182,
+              "targetConstituent": 186
+            },
+            {
+              "relationName": "PMOD",
+              "score": 1.0,
+              "srcConstituent": 186,
+              "targetConstituent": 187
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 187,
+              "targetConstituent": 188
+            },
+            {
+              "relationName": "VC",
+              "score": 1.0,
+              "srcConstituent": 181,
+              "targetConstituent": 189
+            },
+            {
+              "relationName": "PRD",
+              "score": 1.0,
+              "srcConstituent": 189,
+              "targetConstituent": 190
+            },
+            {
+              "relationName": "AMOD",
+              "score": 1.0,
+              "srcConstituent": 190,
+              "targetConstituent": 191
+            },
+            {
+              "relationName": "AMOD",
+              "score": 1.0,
+              "srcConstituent": 190,
+              "targetConstituent": 192
+            },
+            {
+              "relationName": "PMOD",
+              "score": 1.0,
+              "srcConstituent": 192,
+              "targetConstituent": 193
+            },
+            {
+              "relationName": "PMOD",
+              "score": 1.0,
+              "srcConstituent": 163,
+              "targetConstituent": 194
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 162,
+              "targetConstituent": 195
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 161,
+              "targetConstituent": 196
+            },
+            {
+              "relationName": "NMOD",
+              "score": 1.0,
+              "srcConstituent": 196,
+              "targetConstituent": 197
+            },
+            {
+              "relationName": "SBJ",
+              "score": 1.0,
+              "srcConstituent": 161,
+              "targetConstituent": 198
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "viewName": "DEPENDENCY_HEADFINDER:PARSE_STANFORD",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.TreeView",
+          "viewName": "DEPENDENCY_HEADFINDER:PARSE_STANFORD",
+          "generator": "HeadFinderDependencies",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "ROOT",
+              "start": 18,
+              "end": 19
+            },
+            {
+              "label": "Parent: VP, Head: VBD, Child: NP-TMP",
+              "score": 1.0,
+              "start": 19,
+              "end": 20
+            },
+            {
+              "label": "Parent: VP, Head: VBD, Child: PP",
+              "score": 1.0,
+              "start": 20,
+              "end": 21
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "start": 24,
+              "end": 25
+            },
+            {
+              "label": "Parent: NP, Head: NNP, Child: NP",
+              "score": 1.0,
+              "start": 22,
+              "end": 23
+            },
+            {
+              "label": "Parent: NP, Head: POS, Child: NNP",
+              "score": 1.0,
+              "start": 21,
+              "end": 22
+            },
+            {
+              "label": "Parent: NP, Head: NNP, Child: ``",
+              "score": 1.0,
+              "start": 23,
+              "end": 24
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "start": 25,
+              "end": 26
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: ``",
+              "score": 1.0,
+              "start": 26,
+              "end": 27
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: SBAR",
+              "score": 1.0,
+              "start": 27,
+              "end": 28
+            },
+            {
+              "label": "Parent: SBAR, Head: IN, Child: S",
+              "score": 1.0,
+              "start": 29,
+              "end": 30
+            },
+            {
+              "label": "Parent: VP, Head: VBZ, Child: ADJP",
+              "score": 1.0,
+              "start": 30,
+              "end": 31
+            },
+            {
+              "label": "Parent: ADJP, Head: JJ, Child: SBAR",
+              "score": 1.0,
+              "start": 34,
+              "end": 35
+            },
+            {
+              "label": "Parent: VP, Head: VBP, Child: RB",
+              "score": 1.0,
+              "start": 35,
+              "end": 36
+            },
+            {
+              "label": "Parent: VP, Head: VBP, Child: VP",
+              "score": 1.0,
+              "start": 36,
+              "end": 37
+            },
+            {
+              "label": "Parent: VP, Head: VBN, Child: ADVP",
+              "score": 1.0,
+              "start": 37,
+              "end": 38
+            },
+            {
+              "label": "Parent: VP, Head: VBN, Child: NP",
+              "score": 1.0,
+              "start": 38,
+              "end": 39
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "start": 39,
+              "end": 40
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "start": 43,
+              "end": 44
+            },
+            {
+              "label": "Parent: NP, Head: NN, Child: NP",
+              "score": 1.0,
+              "start": 42,
+              "end": 43
+            },
+            {
+              "label": "Parent: NP, Head: POS, Child: NNP",
+              "score": 1.0,
+              "start": 40,
+              "end": 41
+            },
+            {
+              "label": "Parent: NP, Head: POS, Child: NNP",
+              "score": 1.0,
+              "start": 41,
+              "end": 42
+            },
+            {
+              "label": "Parent: VP, Head: VBN, Child: PP",
+              "score": 1.0,
+              "start": 44,
+              "end": 45
+            },
+            {
+              "label": "Parent: PP, Head: TO, Child: NP",
+              "score": 1.0,
+              "start": 49,
+              "end": 50
+            },
+            {
+              "label": "Parent: NP, Head: NNP, Child: NN",
+              "score": 1.0,
+              "start": 45,
+              "end": 46
+            },
+            {
+              "label": "Parent: NP, Head: NNP, Child: NNP",
+              "score": 1.0,
+              "start": 46,
+              "end": 47
+            },
+            {
+              "label": "Parent: NP, Head: NNP, Child: NNP",
+              "score": 1.0,
+              "start": 47,
+              "end": 48
+            },
+            {
+              "label": "Parent: NP, Head: NNP, Child: NNP",
+              "score": 1.0,
+              "start": 48,
+              "end": 49
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 31,
+              "end": 32
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "start": 32,
+              "end": 33
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "start": 33,
+              "end": 34
+            },
+            {
+              "label": "Parent: VP, Head: VBZ, Child: NP-TMP",
+              "score": 1.0,
+              "start": 51,
+              "end": 52
+            },
+            {
+              "label": "Parent: NP-TMP, Head: NN, Child: JJ",
+              "score": 1.0,
+              "start": 50,
+              "end": 51
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 28,
+              "end": 29
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 0,
+              "end": 1
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: ,",
+              "score": 1.0,
+              "start": 1,
+              "end": 2
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: NP",
+              "score": 1.0,
+              "start": 4,
+              "end": 5
+            },
+            {
+              "label": "Parent: NP, Head: NN, Child: DT",
+              "score": 1.0,
+              "start": 2,
+              "end": 3
+            },
+            {
+              "label": "Parent: NP, Head: NN, Child: NNP",
+              "score": 1.0,
+              "start": 3,
+              "end": 4
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: SBAR",
+              "score": 1.0,
+              "start": 6,
+              "end": 7
+            },
+            {
+              "label": "Parent: NP, Head: NN, Child: WP$",
+              "score": 1.0,
+              "start": 5,
+              "end": 6
+            },
+            {
+              "label": "Parent: WHNP, Head: NP, Child: PP",
+              "score": 1.0,
+              "start": 7,
+              "end": 8
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "start": 10,
+              "end": 11
+            },
+            {
+              "label": "Parent: NP, Head: NNP, Child: DT",
+              "score": 1.0,
+              "start": 8,
+              "end": 9
+            },
+            {
+              "label": "Parent: NP, Head: NNP, Child: NNP",
+              "score": 1.0,
+              "start": 9,
+              "end": 10
+            },
+            {
+              "label": "Parent: SBAR, Head: WHNP, Child: S",
+              "score": 1.0,
+              "start": 11,
+              "end": 12
+            },
+            {
+              "label": "Parent: VP, Head: VBD, Child: VP",
+              "score": 1.0,
+              "start": 12,
+              "end": 13
+            },
+            {
+              "label": "Parent: VP, Head: VB, Child: NP",
+              "score": 1.0,
+              "start": 13,
+              "end": 14
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "start": 14,
+              "end": 15
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "start": 16,
+              "end": 17
+            },
+            {
+              "label": "Parent: NP, Head: NNS, Child: DT",
+              "score": 1.0,
+              "start": 15,
+              "end": 16
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: ,",
+              "score": 1.0,
+              "start": 17,
+              "end": 18
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: .",
+              "score": 1.0,
+              "start": 52,
+              "end": 53
+            },
+            {
+              "label": "ROOT",
+              "start": 56,
+              "end": 57
+            },
+            {
+              "label": "Parent: VP, Head: VBD, Child: VP",
+              "score": 1.0,
+              "start": 57,
+              "end": 58
+            },
+            {
+              "label": "Parent: VP, Head: VBG, Child: NP",
+              "score": 1.0,
+              "start": 59,
+              "end": 60
+            },
+            {
+              "label": "Parent: NP, Head: NNS, Child: JJ",
+              "score": 1.0,
+              "start": 58,
+              "end": 59
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "start": 60,
+              "end": 61
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "start": 64,
+              "end": 65
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: NP",
+              "score": 1.0,
+              "start": 65,
+              "end": 66
+            },
+            {
+              "label": "Parent: NP, Head: CC, Child: NP",
+              "score": 1.0,
+              "start": 63,
+              "end": 64
+            },
+            {
+              "label": "Parent: NP, Head: NN, Child: DT",
+              "score": 1.0,
+              "start": 61,
+              "end": 62
+            },
+            {
+              "label": "Parent: NP, Head: NN, Child: NNP",
+              "score": 1.0,
+              "start": 62,
+              "end": 63
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 55,
+              "end": 56
+            },
+            {
+              "label": "Parent: NP, Head: NN, Child: NP",
+              "score": 1.0,
+              "start": 54,
+              "end": 55
+            },
+            {
+              "label": "Parent: NP, Head: POS, Child: NNP",
+              "score": 1.0,
+              "start": 53,
+              "end": 54
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: .",
+              "score": 1.0,
+              "start": 66,
+              "end": 67
+            },
+            {
+              "label": "ROOT",
+              "start": 67,
+              "end": 68
+            },
+            {
+              "label": "Parent: S, Head: S, Child: :",
+              "score": 1.0,
+              "start": 68,
+              "end": 69
+            },
+            {
+              "label": "Parent: S, Head: S, Child: S",
+              "score": 1.0,
+              "start": 77,
+              "end": 78
+            },
+            {
+              "label": "Parent: VP, Head: VBP, Child: VP",
+              "score": 1.0,
+              "start": 78,
+              "end": 79
+            },
+            {
+              "label": "Parent: VP, Head: VBN, Child: PP",
+              "score": 1.0,
+              "start": 79,
+              "end": 80
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: \u0027\u0027",
+              "score": 1.0,
+              "start": 80,
+              "end": 81
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "start": 83,
+              "end": 84
+            },
+            {
+              "label": "Parent: NP, Head: NNS, Child: VBG",
+              "score": 1.0,
+              "start": 81,
+              "end": 82
+            },
+            {
+              "label": "Parent: NP, Head: NNS, Child: NN",
+              "score": 1.0,
+              "start": 82,
+              "end": 83
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: SBAR",
+              "score": 1.0,
+              "start": 89,
+              "end": 90
+            },
+            {
+              "label": "Parent: VP, Head: VBD, Child: ADJP",
+              "score": 1.0,
+              "start": 90,
+              "end": 91
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: ``",
+              "score": 1.0,
+              "start": 84,
+              "end": 85
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 86,
+              "end": 87
+            },
+            {
+              "label": "Parent: NP, Head: NNPS, Child: DT",
+              "score": 1.0,
+              "start": 85,
+              "end": 86
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "start": 87,
+              "end": 88
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "start": 88,
+              "end": 89
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 71,
+              "end": 72
+            },
+            {
+              "label": "Parent: NP, Head: NN, Child: NP",
+              "score": 1.0,
+              "start": 70,
+              "end": 71
+            },
+            {
+              "label": "Parent: NP, Head: POS, Child: NNP",
+              "score": 1.0,
+              "start": 69,
+              "end": 70
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "start": 72,
+              "end": 73
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "start": 73,
+              "end": 74
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: :",
+              "score": 1.0,
+              "start": 74,
+              "end": 75
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: \u0027\u0027",
+              "score": 1.0,
+              "start": 75,
+              "end": 76
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: ADVP",
+              "score": 1.0,
+              "start": 76,
+              "end": 77
+            },
+            {
+              "label": "Parent: S, Head: S, Child: .",
+              "score": 1.0,
+              "start": 91,
+              "end": 92
+            },
+            {
+              "label": "ROOT",
+              "start": 116,
+              "end": 117
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: SBARQ",
+              "score": 1.0,
+              "start": 101,
+              "end": 102
+            },
+            {
+              "label": "Parent: VP, Head: VBD, Child: SBAR",
+              "score": 1.0,
+              "start": 106,
+              "end": 107
+            },
+            {
+              "label": "Parent: SBAR, Head: SBAR, Child: ,",
+              "score": 1.0,
+              "start": 105,
+              "end": 106
+            },
+            {
+              "label": "Parent: SBAR, Head: SBAR, Child: SBAR",
+              "score": 1.0,
+              "start": 107,
+              "end": 108
+            },
+            {
+              "label": "Parent: SBAR, Head: WHADVP, Child: S",
+              "score": 1.0,
+              "start": 108,
+              "end": 109
+            },
+            {
+              "label": "Parent: VP, Head: VBD, Child: S",
+              "score": 1.0,
+              "start": 110,
+              "end": 111
+            },
+            {
+              "label": "Parent: VP, Head: VB, Child: NP",
+              "score": 1.0,
+              "start": 111,
+              "end": 112
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 109,
+              "end": 110
+            },
+            {
+              "label": "Parent: SBAR, Head: CC, Child: SBAR",
+              "score": 1.0,
+              "start": 104,
+              "end": 105
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 103,
+              "end": 104
+            },
+            {
+              "label": "Parent: NP, Head: NN, Child: DT",
+              "score": 1.0,
+              "start": 102,
+              "end": 103
+            },
+            {
+              "label": "Parent: SBARQ, Head: SQ, Child: S",
+              "score": 1.0,
+              "start": 93,
+              "end": 94
+            },
+            {
+              "label": "Parent: VP, Head: VBP, Child: NP",
+              "score": 1.0,
+              "start": 95,
+              "end": 96
+            },
+            {
+              "label": "Parent: NP, Head: NNS, Child: DT",
+              "score": 1.0,
+              "start": 94,
+              "end": 95
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: SBAR",
+              "score": 1.0,
+              "start": 96,
+              "end": 97
+            },
+            {
+              "label": "Parent: SBAR, Head: WHNP, Child: S",
+              "score": 1.0,
+              "start": 97,
+              "end": 98
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 92,
+              "end": 93
+            },
+            {
+              "label": "Parent: SBARQ, Head: SQ, Child: ,",
+              "score": 1.0,
+              "start": 98,
+              "end": 99
+            },
+            {
+              "label": "Parent: SBARQ, Head: SQ, Child: \u0027\u0027",
+              "score": 1.0,
+              "start": 99,
+              "end": 100
+            },
+            {
+              "label": "Parent: SBARQ, Head: SQ, Child: WHNP",
+              "score": 1.0,
+              "start": 100,
+              "end": 101
+            },
+            {
+              "label": "Parent: SBARQ, Head: SQ, Child: .",
+              "score": 1.0,
+              "start": 112,
+              "end": 113
+            },
+            {
+              "label": "Parent: SBARQ, Head: SQ, Child: \u0027\u0027",
+              "score": 1.0,
+              "start": 113,
+              "end": 114
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 115,
+              "end": 116
+            },
+            {
+              "label": "Parent: NP, Head: NNP, Child: ``",
+              "score": 1.0,
+              "start": 114,
+              "end": 115
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: .",
+              "score": 1.0,
+              "start": 117,
+              "end": 118
+            },
+            {
+              "label": "ROOT",
+              "start": 119,
+              "end": 120
+            },
+            {
+              "label": "Parent: VP, Head: VBD, Child: SBAR",
+              "score": 1.0,
+              "start": 120,
+              "end": 121
+            },
+            {
+              "label": "Parent: SBAR, Head: IN, Child: S",
+              "score": 1.0,
+              "start": 124,
+              "end": 125
+            },
+            {
+              "label": "Parent: VP, Head: VBD, Child: VBD",
+              "score": 1.0,
+              "start": 125,
+              "end": 126
+            },
+            {
+              "label": "Parent: VP, Head: VBD, Child: NP",
+              "score": 1.0,
+              "start": 127,
+              "end": 128
+            },
+            {
+              "label": "Parent: NP, Head: NN, Child: DT",
+              "score": 1.0,
+              "start": 126,
+              "end": 127
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "start": 128,
+              "end": 129
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "start": 129,
+              "end": 130
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: ``",
+              "score": 1.0,
+              "start": 130,
+              "end": 131
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: SBAR",
+              "score": 1.0,
+              "start": 131,
+              "end": 132
+            },
+            {
+              "label": "Parent: SBAR, Head: IN, Child: S",
+              "score": 1.0,
+              "start": 133,
+              "end": 134
+            },
+            {
+              "label": "Parent: VP, Head: VBD, Child: ADJP",
+              "score": 1.0,
+              "start": 134,
+              "end": 135
+            },
+            {
+              "label": "Parent: ADJP, Head: JJ, Child: S",
+              "score": 1.0,
+              "start": 135,
+              "end": 136
+            },
+            {
+              "label": "Parent: VP, Head: TO, Child: VP",
+              "score": 1.0,
+              "start": 136,
+              "end": 137
+            },
+            {
+              "label": "Parent: VP, Head: VB, Child: SBAR",
+              "score": 1.0,
+              "start": 139,
+              "end": 140
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 138,
+              "end": 139
+            },
+            {
+              "label": "Parent: NP, Head: NN, Child: DT",
+              "score": 1.0,
+              "start": 137,
+              "end": 138
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 132,
+              "end": 133
+            },
+            {
+              "label": "Parent: VP, Head: CC, Child: VBD",
+              "score": 1.0,
+              "start": 123,
+              "end": 124
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 122,
+              "end": 123
+            },
+            {
+              "label": "Parent: NP, Head: NNPS, Child: DT",
+              "score": 1.0,
+              "start": 121,
+              "end": 122
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 118,
+              "end": 119
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: .",
+              "score": 1.0,
+              "start": 140,
+              "end": 141
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: \u0027\u0027",
+              "score": 1.0,
+              "start": 141,
+              "end": 142
+            },
+            {
+              "label": "ROOT",
+              "start": 143,
+              "end": 144
+            },
+            {
+              "label": "Parent: VP, Head: VBD, Child: SBAR",
+              "score": 1.0,
+              "start": 144,
+              "end": 145
+            },
+            {
+              "label": "Parent: SBAR, Head: IN, Child: S",
+              "score": 1.0,
+              "start": 153,
+              "end": 154
+            },
+            {
+              "label": "Parent: VP, Head: MD, Child: VP",
+              "score": 1.0,
+              "start": 154,
+              "end": 155
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 146,
+              "end": 147
+            },
+            {
+              "label": "Parent: NP, Head: NN, Child: DT",
+              "score": 1.0,
+              "start": 145,
+              "end": 146
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "start": 147,
+              "end": 148
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "start": 152,
+              "end": 153
+            },
+            {
+              "label": "Parent: NP, Head: NNP, Child: DT",
+              "score": 1.0,
+              "start": 148,
+              "end": 149
+            },
+            {
+              "label": "Parent: NP, Head: NNP, Child: NNP",
+              "score": 1.0,
+              "start": 149,
+              "end": 150
+            },
+            {
+              "label": "Parent: NP, Head: NNP, Child: .",
+              "score": 1.0,
+              "start": 150,
+              "end": 151
+            },
+            {
+              "label": "Parent: NP, Head: NNP, Child: NNP",
+              "score": 1.0,
+              "start": 151,
+              "end": 152
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 142,
+              "end": 143
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: .",
+              "score": 1.0,
+              "start": 155,
+              "end": 156
+            },
+            {
+              "label": "ROOT",
+              "start": 157,
+              "end": 158
+            },
+            {
+              "label": "Parent: VP, Head: VBD, Child: SBAR",
+              "score": 1.0,
+              "start": 159,
+              "end": 160
+            },
+            {
+              "label": "Parent: VP, Head: VBZ, Child: RB",
+              "score": 1.0,
+              "start": 160,
+              "end": 161
+            },
+            {
+              "label": "Parent: VP, Head: VBZ, Child: VP",
+              "score": 1.0,
+              "start": 161,
+              "end": 162
+            },
+            {
+              "label": "Parent: VP, Head: VBN, Child: NP",
+              "score": 1.0,
+              "start": 163,
+              "end": 164
+            },
+            {
+              "label": "Parent: NP, Head: NN, Child: JJ",
+              "score": 1.0,
+              "start": 164,
+              "end": 165
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: ``",
+              "score": 1.0,
+              "start": 162,
+              "end": 163
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: ``",
+              "score": 1.0,
+              "start": 165,
+              "end": 166
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "start": 167,
+              "end": 168
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: ADVP",
+              "score": 1.0,
+              "start": 166,
+              "end": 167
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "start": 168,
+              "end": 169
+            },
+            {
+              "label": "Parent: VP, Head: VBN, Child: NP-TMP",
+              "score": 1.0,
+              "start": 169,
+              "end": 170
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 158,
+              "end": 159
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 156,
+              "end": 157
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: .",
+              "score": 1.0,
+              "start": 170,
+              "end": 171
+            },
+            {
+              "label": "ROOT",
+              "start": 190,
+              "end": 191
+            },
+            {
+              "label": "Parent: VP, Head: VBZ, Child: VP",
+              "score": 1.0,
+              "start": 191,
+              "end": 192
+            },
+            {
+              "label": "Parent: VP, Head: VBN, Child: ADJP",
+              "score": 1.0,
+              "start": 194,
+              "end": 195
+            },
+            {
+              "label": "Parent: ADJP, Head: JJ, Child: JJ",
+              "score": 1.0,
+              "start": 195,
+              "end": 196
+            },
+            {
+              "label": "Parent: ADJP, Head: CC, Child: JJ",
+              "score": 1.0,
+              "start": 193,
+              "end": 194
+            },
+            {
+              "label": "Parent: ADJP, Head: JJ, Child: RB",
+              "score": 1.0,
+              "start": 192,
+              "end": 193
+            },
+            {
+              "label": "Parent: VP, Head: VBN, Child: PP",
+              "score": 1.0,
+              "start": 196,
+              "end": 197
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "start": 197,
+              "end": 198
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: S",
+              "score": 1.0,
+              "start": 172,
+              "end": 173
+            },
+            {
+              "label": "Parent: VP, Head: VBD, Child: SBAR",
+              "score": 1.0,
+              "start": 173,
+              "end": 174
+            },
+            {
+              "label": "Parent: SBAR, Head: IN, Child: S",
+              "score": 1.0,
+              "start": 181,
+              "end": 182
+            },
+            {
+              "label": "Parent: VP, Head: VBP, Child: VP",
+              "score": 1.0,
+              "start": 182,
+              "end": 183
+            },
+            {
+              "label": "Parent: VP, Head: VBN, Child: ADVP",
+              "score": 1.0,
+              "start": 183,
+              "end": 184
+            },
+            {
+              "label": "Parent: VP, Head: VBN, Child: ADJP",
+              "score": 1.0,
+              "start": 184,
+              "end": 185
+            },
+            {
+              "label": "Parent: ADJP, Head: JJ, Child: PP",
+              "score": 1.0,
+              "start": 185,
+              "end": 186
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "start": 186,
+              "end": 187
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 177,
+              "end": 178
+            },
+            {
+              "label": "Parent: NP, Head: NNS, Child: ``",
+              "score": 1.0,
+              "start": 174,
+              "end": 175
+            },
+            {
+              "label": "Parent: NP, Head: NNS, Child: JJ",
+              "score": 1.0,
+              "start": 175,
+              "end": 176
+            },
+            {
+              "label": "Parent: NP, Head: NNS, Child: \u0027\u0027",
+              "score": 1.0,
+              "start": 176,
+              "end": 177
+            },
+            {
+              "label": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "start": 178,
+              "end": 179
+            },
+            {
+              "label": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "start": 180,
+              "end": 181
+            },
+            {
+              "label": "Parent: NP, Head: NN, Child: DT",
+              "score": 1.0,
+              "start": 179,
+              "end": 180
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 171,
+              "end": 172
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: ,",
+              "score": 1.0,
+              "start": 187,
+              "end": 188
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "start": 189,
+              "end": 190
+            },
+            {
+              "label": "Parent: NP, Head: NN, Child: JJ",
+              "score": 1.0,
+              "start": 188,
+              "end": 189
+            },
+            {
+              "label": "Parent: S, Head: VP, Child: .",
+              "score": 1.0,
+              "start": 198,
+              "end": 199
+            }
+          ],
+          "relations": [
+            {
+              "relationName": "Parent: VP, Head: VBD, Child: NP-TMP",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 1
+            },
+            {
+              "relationName": "Parent: VP, Head: VBD, Child: PP",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 2
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 2,
+              "targetConstituent": 3
+            },
+            {
+              "relationName": "Parent: NP, Head: NNP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 3,
+              "targetConstituent": 4
+            },
+            {
+              "relationName": "Parent: NP, Head: POS, Child: NNP",
+              "score": 1.0,
+              "srcConstituent": 4,
+              "targetConstituent": 5
+            },
+            {
+              "relationName": "Parent: NP, Head: NNP, Child: ``",
+              "score": 1.0,
+              "srcConstituent": 3,
+              "targetConstituent": 6
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 2,
+              "targetConstituent": 7
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: ``",
+              "score": 1.0,
+              "srcConstituent": 7,
+              "targetConstituent": 8
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: SBAR",
+              "score": 1.0,
+              "srcConstituent": 7,
+              "targetConstituent": 9
+            },
+            {
+              "relationName": "Parent: SBAR, Head: IN, Child: S",
+              "score": 1.0,
+              "srcConstituent": 9,
+              "targetConstituent": 10
+            },
+            {
+              "relationName": "Parent: VP, Head: VBZ, Child: ADJP",
+              "score": 1.0,
+              "srcConstituent": 10,
+              "targetConstituent": 11
+            },
+            {
+              "relationName": "Parent: ADJP, Head: JJ, Child: SBAR",
+              "score": 1.0,
+              "srcConstituent": 11,
+              "targetConstituent": 12
+            },
+            {
+              "relationName": "Parent: VP, Head: VBP, Child: RB",
+              "score": 1.0,
+              "srcConstituent": 12,
+              "targetConstituent": 13
+            },
+            {
+              "relationName": "Parent: VP, Head: VBP, Child: VP",
+              "score": 1.0,
+              "srcConstituent": 12,
+              "targetConstituent": 14
+            },
+            {
+              "relationName": "Parent: VP, Head: VBN, Child: ADVP",
+              "score": 1.0,
+              "srcConstituent": 14,
+              "targetConstituent": 15
+            },
+            {
+              "relationName": "Parent: VP, Head: VBN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 14,
+              "targetConstituent": 16
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "srcConstituent": 16,
+              "targetConstituent": 17
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 17,
+              "targetConstituent": 18
+            },
+            {
+              "relationName": "Parent: NP, Head: NN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 18,
+              "targetConstituent": 19
+            },
+            {
+              "relationName": "Parent: NP, Head: POS, Child: NNP",
+              "score": 1.0,
+              "srcConstituent": 19,
+              "targetConstituent": 20
+            },
+            {
+              "relationName": "Parent: NP, Head: POS, Child: NNP",
+              "score": 1.0,
+              "srcConstituent": 19,
+              "targetConstituent": 21
+            },
+            {
+              "relationName": "Parent: VP, Head: VBN, Child: PP",
+              "score": 1.0,
+              "srcConstituent": 14,
+              "targetConstituent": 22
+            },
+            {
+              "relationName": "Parent: PP, Head: TO, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 22,
+              "targetConstituent": 23
+            },
+            {
+              "relationName": "Parent: NP, Head: NNP, Child: NN",
+              "score": 1.0,
+              "srcConstituent": 23,
+              "targetConstituent": 24
+            },
+            {
+              "relationName": "Parent: NP, Head: NNP, Child: NNP",
+              "score": 1.0,
+              "srcConstituent": 23,
+              "targetConstituent": 25
+            },
+            {
+              "relationName": "Parent: NP, Head: NNP, Child: NNP",
+              "score": 1.0,
+              "srcConstituent": 23,
+              "targetConstituent": 26
+            },
+            {
+              "relationName": "Parent: NP, Head: NNP, Child: NNP",
+              "score": 1.0,
+              "srcConstituent": 23,
+              "targetConstituent": 27
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 12,
+              "targetConstituent": 28
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "srcConstituent": 28,
+              "targetConstituent": 29
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 29,
+              "targetConstituent": 30
+            },
+            {
+              "relationName": "Parent: VP, Head: VBZ, Child: NP-TMP",
+              "score": 1.0,
+              "srcConstituent": 10,
+              "targetConstituent": 31
+            },
+            {
+              "relationName": "Parent: NP-TMP, Head: NN, Child: JJ",
+              "score": 1.0,
+              "srcConstituent": 31,
+              "targetConstituent": 32
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 10,
+              "targetConstituent": 33
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 34
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: ,",
+              "score": 1.0,
+              "srcConstituent": 34,
+              "targetConstituent": 35
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 34,
+              "targetConstituent": 36
+            },
+            {
+              "relationName": "Parent: NP, Head: NN, Child: DT",
+              "score": 1.0,
+              "srcConstituent": 36,
+              "targetConstituent": 37
+            },
+            {
+              "relationName": "Parent: NP, Head: NN, Child: NNP",
+              "score": 1.0,
+              "srcConstituent": 36,
+              "targetConstituent": 38
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: SBAR",
+              "score": 1.0,
+              "srcConstituent": 36,
+              "targetConstituent": 39
+            },
+            {
+              "relationName": "Parent: NP, Head: NN, Child: WP$",
+              "score": 1.0,
+              "srcConstituent": 39,
+              "targetConstituent": 40
+            },
+            {
+              "relationName": "Parent: WHNP, Head: NP, Child: PP",
+              "score": 1.0,
+              "srcConstituent": 39,
+              "targetConstituent": 41
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 41,
+              "targetConstituent": 42
+            },
+            {
+              "relationName": "Parent: NP, Head: NNP, Child: DT",
+              "score": 1.0,
+              "srcConstituent": 42,
+              "targetConstituent": 43
+            },
+            {
+              "relationName": "Parent: NP, Head: NNP, Child: NNP",
+              "score": 1.0,
+              "srcConstituent": 42,
+              "targetConstituent": 44
+            },
+            {
+              "relationName": "Parent: SBAR, Head: WHNP, Child: S",
+              "score": 1.0,
+              "srcConstituent": 39,
+              "targetConstituent": 45
+            },
+            {
+              "relationName": "Parent: VP, Head: VBD, Child: VP",
+              "score": 1.0,
+              "srcConstituent": 45,
+              "targetConstituent": 46
+            },
+            {
+              "relationName": "Parent: VP, Head: VB, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 46,
+              "targetConstituent": 47
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "srcConstituent": 47,
+              "targetConstituent": 48
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 48,
+              "targetConstituent": 49
+            },
+            {
+              "relationName": "Parent: NP, Head: NNS, Child: DT",
+              "score": 1.0,
+              "srcConstituent": 49,
+              "targetConstituent": 50
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: ,",
+              "score": 1.0,
+              "srcConstituent": 34,
+              "targetConstituent": 51
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: .",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 52
+            },
+            {
+              "relationName": "Parent: VP, Head: VBD, Child: VP",
+              "score": 1.0,
+              "srcConstituent": 53,
+              "targetConstituent": 54
+            },
+            {
+              "relationName": "Parent: VP, Head: VBG, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 54,
+              "targetConstituent": 55
+            },
+            {
+              "relationName": "Parent: NP, Head: NNS, Child: JJ",
+              "score": 1.0,
+              "srcConstituent": 55,
+              "targetConstituent": 56
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "srcConstituent": 55,
+              "targetConstituent": 57
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 57,
+              "targetConstituent": 58
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 58,
+              "targetConstituent": 59
+            },
+            {
+              "relationName": "Parent: NP, Head: CC, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 58,
+              "targetConstituent": 60
+            },
+            {
+              "relationName": "Parent: NP, Head: NN, Child: DT",
+              "score": 1.0,
+              "srcConstituent": 60,
+              "targetConstituent": 61
+            },
+            {
+              "relationName": "Parent: NP, Head: NN, Child: NNP",
+              "score": 1.0,
+              "srcConstituent": 60,
+              "targetConstituent": 62
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 53,
+              "targetConstituent": 63
+            },
+            {
+              "relationName": "Parent: NP, Head: NN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 63,
+              "targetConstituent": 64
+            },
+            {
+              "relationName": "Parent: NP, Head: POS, Child: NNP",
+              "score": 1.0,
+              "srcConstituent": 64,
+              "targetConstituent": 65
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: .",
+              "score": 1.0,
+              "srcConstituent": 53,
+              "targetConstituent": 66
+            },
+            {
+              "relationName": "Parent: S, Head: S, Child: :",
+              "score": 1.0,
+              "srcConstituent": 67,
+              "targetConstituent": 68
+            },
+            {
+              "relationName": "Parent: S, Head: S, Child: S",
+              "score": 1.0,
+              "srcConstituent": 67,
+              "targetConstituent": 69
+            },
+            {
+              "relationName": "Parent: VP, Head: VBP, Child: VP",
+              "score": 1.0,
+              "srcConstituent": 69,
+              "targetConstituent": 70
+            },
+            {
+              "relationName": "Parent: VP, Head: VBN, Child: PP",
+              "score": 1.0,
+              "srcConstituent": 70,
+              "targetConstituent": 71
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: \u0027\u0027",
+              "score": 1.0,
+              "srcConstituent": 71,
+              "targetConstituent": 72
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 71,
+              "targetConstituent": 73
+            },
+            {
+              "relationName": "Parent: NP, Head: NNS, Child: VBG",
+              "score": 1.0,
+              "srcConstituent": 73,
+              "targetConstituent": 74
+            },
+            {
+              "relationName": "Parent: NP, Head: NNS, Child: NN",
+              "score": 1.0,
+              "srcConstituent": 73,
+              "targetConstituent": 75
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: SBAR",
+              "score": 1.0,
+              "srcConstituent": 73,
+              "targetConstituent": 76
+            },
+            {
+              "relationName": "Parent: VP, Head: VBD, Child: ADJP",
+              "score": 1.0,
+              "srcConstituent": 76,
+              "targetConstituent": 77
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: ``",
+              "score": 1.0,
+              "srcConstituent": 76,
+              "targetConstituent": 78
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 76,
+              "targetConstituent": 79
+            },
+            {
+              "relationName": "Parent: NP, Head: NNPS, Child: DT",
+              "score": 1.0,
+              "srcConstituent": 79,
+              "targetConstituent": 80
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "srcConstituent": 79,
+              "targetConstituent": 81
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 81,
+              "targetConstituent": 82
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 69,
+              "targetConstituent": 83
+            },
+            {
+              "relationName": "Parent: NP, Head: NN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 83,
+              "targetConstituent": 84
+            },
+            {
+              "relationName": "Parent: NP, Head: POS, Child: NNP",
+              "score": 1.0,
+              "srcConstituent": 84,
+              "targetConstituent": 85
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "srcConstituent": 83,
+              "targetConstituent": 86
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 86,
+              "targetConstituent": 87
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: :",
+              "score": 1.0,
+              "srcConstituent": 83,
+              "targetConstituent": 88
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: \u0027\u0027",
+              "score": 1.0,
+              "srcConstituent": 83,
+              "targetConstituent": 89
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: ADVP",
+              "score": 1.0,
+              "srcConstituent": 69,
+              "targetConstituent": 90
+            },
+            {
+              "relationName": "Parent: S, Head: S, Child: .",
+              "score": 1.0,
+              "srcConstituent": 67,
+              "targetConstituent": 91
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: SBARQ",
+              "score": 1.0,
+              "srcConstituent": 92,
+              "targetConstituent": 93
+            },
+            {
+              "relationName": "Parent: VP, Head: VBD, Child: SBAR",
+              "score": 1.0,
+              "srcConstituent": 93,
+              "targetConstituent": 94
+            },
+            {
+              "relationName": "Parent: SBAR, Head: SBAR, Child: ,",
+              "score": 1.0,
+              "srcConstituent": 94,
+              "targetConstituent": 95
+            },
+            {
+              "relationName": "Parent: SBAR, Head: SBAR, Child: SBAR",
+              "score": 1.0,
+              "srcConstituent": 94,
+              "targetConstituent": 96
+            },
+            {
+              "relationName": "Parent: SBAR, Head: WHADVP, Child: S",
+              "score": 1.0,
+              "srcConstituent": 96,
+              "targetConstituent": 97
+            },
+            {
+              "relationName": "Parent: VP, Head: VBD, Child: S",
+              "score": 1.0,
+              "srcConstituent": 97,
+              "targetConstituent": 98
+            },
+            {
+              "relationName": "Parent: VP, Head: VB, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 98,
+              "targetConstituent": 99
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 98,
+              "targetConstituent": 100
+            },
+            {
+              "relationName": "Parent: SBAR, Head: CC, Child: SBAR",
+              "score": 1.0,
+              "srcConstituent": 94,
+              "targetConstituent": 101
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 101,
+              "targetConstituent": 102
+            },
+            {
+              "relationName": "Parent: NP, Head: NN, Child: DT",
+              "score": 1.0,
+              "srcConstituent": 102,
+              "targetConstituent": 103
+            },
+            {
+              "relationName": "Parent: SBARQ, Head: SQ, Child: S",
+              "score": 1.0,
+              "srcConstituent": 93,
+              "targetConstituent": 104
+            },
+            {
+              "relationName": "Parent: VP, Head: VBP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 104,
+              "targetConstituent": 105
+            },
+            {
+              "relationName": "Parent: NP, Head: NNS, Child: DT",
+              "score": 1.0,
+              "srcConstituent": 105,
+              "targetConstituent": 106
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: SBAR",
+              "score": 1.0,
+              "srcConstituent": 105,
+              "targetConstituent": 107
+            },
+            {
+              "relationName": "Parent: SBAR, Head: WHNP, Child: S",
+              "score": 1.0,
+              "srcConstituent": 107,
+              "targetConstituent": 108
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 104,
+              "targetConstituent": 109
+            },
+            {
+              "relationName": "Parent: SBARQ, Head: SQ, Child: ,",
+              "score": 1.0,
+              "srcConstituent": 93,
+              "targetConstituent": 110
+            },
+            {
+              "relationName": "Parent: SBARQ, Head: SQ, Child: \u0027\u0027",
+              "score": 1.0,
+              "srcConstituent": 93,
+              "targetConstituent": 111
+            },
+            {
+              "relationName": "Parent: SBARQ, Head: SQ, Child: WHNP",
+              "score": 1.0,
+              "srcConstituent": 93,
+              "targetConstituent": 112
+            },
+            {
+              "relationName": "Parent: SBARQ, Head: SQ, Child: .",
+              "score": 1.0,
+              "srcConstituent": 93,
+              "targetConstituent": 113
+            },
+            {
+              "relationName": "Parent: SBARQ, Head: SQ, Child: \u0027\u0027",
+              "score": 1.0,
+              "srcConstituent": 93,
+              "targetConstituent": 114
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 92,
+              "targetConstituent": 115
+            },
+            {
+              "relationName": "Parent: NP, Head: NNP, Child: ``",
+              "score": 1.0,
+              "srcConstituent": 115,
+              "targetConstituent": 116
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: .",
+              "score": 1.0,
+              "srcConstituent": 92,
+              "targetConstituent": 117
+            },
+            {
+              "relationName": "Parent: VP, Head: VBD, Child: SBAR",
+              "score": 1.0,
+              "srcConstituent": 118,
+              "targetConstituent": 119
+            },
+            {
+              "relationName": "Parent: SBAR, Head: IN, Child: S",
+              "score": 1.0,
+              "srcConstituent": 119,
+              "targetConstituent": 120
+            },
+            {
+              "relationName": "Parent: VP, Head: VBD, Child: VBD",
+              "score": 1.0,
+              "srcConstituent": 120,
+              "targetConstituent": 121
+            },
+            {
+              "relationName": "Parent: VP, Head: VBD, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 120,
+              "targetConstituent": 122
+            },
+            {
+              "relationName": "Parent: NP, Head: NN, Child: DT",
+              "score": 1.0,
+              "srcConstituent": 122,
+              "targetConstituent": 123
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "srcConstituent": 122,
+              "targetConstituent": 124
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 124,
+              "targetConstituent": 125
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: ``",
+              "score": 1.0,
+              "srcConstituent": 125,
+              "targetConstituent": 126
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: SBAR",
+              "score": 1.0,
+              "srcConstituent": 125,
+              "targetConstituent": 127
+            },
+            {
+              "relationName": "Parent: SBAR, Head: IN, Child: S",
+              "score": 1.0,
+              "srcConstituent": 127,
+              "targetConstituent": 128
+            },
+            {
+              "relationName": "Parent: VP, Head: VBD, Child: ADJP",
+              "score": 1.0,
+              "srcConstituent": 128,
+              "targetConstituent": 129
+            },
+            {
+              "relationName": "Parent: ADJP, Head: JJ, Child: S",
+              "score": 1.0,
+              "srcConstituent": 129,
+              "targetConstituent": 130
+            },
+            {
+              "relationName": "Parent: VP, Head: TO, Child: VP",
+              "score": 1.0,
+              "srcConstituent": 130,
+              "targetConstituent": 131
+            },
+            {
+              "relationName": "Parent: VP, Head: VB, Child: SBAR",
+              "score": 1.0,
+              "srcConstituent": 131,
+              "targetConstituent": 132
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 132,
+              "targetConstituent": 133
+            },
+            {
+              "relationName": "Parent: NP, Head: NN, Child: DT",
+              "score": 1.0,
+              "srcConstituent": 133,
+              "targetConstituent": 134
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 128,
+              "targetConstituent": 135
+            },
+            {
+              "relationName": "Parent: VP, Head: CC, Child: VBD",
+              "score": 1.0,
+              "srcConstituent": 120,
+              "targetConstituent": 136
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 120,
+              "targetConstituent": 137
+            },
+            {
+              "relationName": "Parent: NP, Head: NNPS, Child: DT",
+              "score": 1.0,
+              "srcConstituent": 137,
+              "targetConstituent": 138
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 118,
+              "targetConstituent": 139
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: .",
+              "score": 1.0,
+              "srcConstituent": 118,
+              "targetConstituent": 140
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: \u0027\u0027",
+              "score": 1.0,
+              "srcConstituent": 118,
+              "targetConstituent": 141
+            },
+            {
+              "relationName": "Parent: VP, Head: VBD, Child: SBAR",
+              "score": 1.0,
+              "srcConstituent": 142,
+              "targetConstituent": 143
+            },
+            {
+              "relationName": "Parent: SBAR, Head: IN, Child: S",
+              "score": 1.0,
+              "srcConstituent": 143,
+              "targetConstituent": 144
+            },
+            {
+              "relationName": "Parent: VP, Head: MD, Child: VP",
+              "score": 1.0,
+              "srcConstituent": 144,
+              "targetConstituent": 145
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 144,
+              "targetConstituent": 146
+            },
+            {
+              "relationName": "Parent: NP, Head: NN, Child: DT",
+              "score": 1.0,
+              "srcConstituent": 146,
+              "targetConstituent": 147
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "srcConstituent": 146,
+              "targetConstituent": 148
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 148,
+              "targetConstituent": 149
+            },
+            {
+              "relationName": "Parent: NP, Head: NNP, Child: DT",
+              "score": 1.0,
+              "srcConstituent": 149,
+              "targetConstituent": 150
+            },
+            {
+              "relationName": "Parent: NP, Head: NNP, Child: NNP",
+              "score": 1.0,
+              "srcConstituent": 149,
+              "targetConstituent": 151
+            },
+            {
+              "relationName": "Parent: NP, Head: NNP, Child: .",
+              "score": 1.0,
+              "srcConstituent": 149,
+              "targetConstituent": 152
+            },
+            {
+              "relationName": "Parent: NP, Head: NNP, Child: NNP",
+              "score": 1.0,
+              "srcConstituent": 149,
+              "targetConstituent": 153
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 142,
+              "targetConstituent": 154
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: .",
+              "score": 1.0,
+              "srcConstituent": 142,
+              "targetConstituent": 155
+            },
+            {
+              "relationName": "Parent: VP, Head: VBD, Child: SBAR",
+              "score": 1.0,
+              "srcConstituent": 156,
+              "targetConstituent": 157
+            },
+            {
+              "relationName": "Parent: VP, Head: VBZ, Child: RB",
+              "score": 1.0,
+              "srcConstituent": 157,
+              "targetConstituent": 158
+            },
+            {
+              "relationName": "Parent: VP, Head: VBZ, Child: VP",
+              "score": 1.0,
+              "srcConstituent": 157,
+              "targetConstituent": 159
+            },
+            {
+              "relationName": "Parent: VP, Head: VBN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 159,
+              "targetConstituent": 160
+            },
+            {
+              "relationName": "Parent: NP, Head: NN, Child: JJ",
+              "score": 1.0,
+              "srcConstituent": 160,
+              "targetConstituent": 161
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: ``",
+              "score": 1.0,
+              "srcConstituent": 160,
+              "targetConstituent": 162
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: ``",
+              "score": 1.0,
+              "srcConstituent": 160,
+              "targetConstituent": 163
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "srcConstituent": 160,
+              "targetConstituent": 164
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: ADVP",
+              "score": 1.0,
+              "srcConstituent": 164,
+              "targetConstituent": 165
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 164,
+              "targetConstituent": 166
+            },
+            {
+              "relationName": "Parent: VP, Head: VBN, Child: NP-TMP",
+              "score": 1.0,
+              "srcConstituent": 159,
+              "targetConstituent": 167
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 157,
+              "targetConstituent": 168
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 156,
+              "targetConstituent": 169
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: .",
+              "score": 1.0,
+              "srcConstituent": 156,
+              "targetConstituent": 170
+            },
+            {
+              "relationName": "Parent: VP, Head: VBZ, Child: VP",
+              "score": 1.0,
+              "srcConstituent": 171,
+              "targetConstituent": 172
+            },
+            {
+              "relationName": "Parent: VP, Head: VBN, Child: ADJP",
+              "score": 1.0,
+              "srcConstituent": 172,
+              "targetConstituent": 173
+            },
+            {
+              "relationName": "Parent: ADJP, Head: JJ, Child: JJ",
+              "score": 1.0,
+              "srcConstituent": 173,
+              "targetConstituent": 174
+            },
+            {
+              "relationName": "Parent: ADJP, Head: CC, Child: JJ",
+              "score": 1.0,
+              "srcConstituent": 173,
+              "targetConstituent": 175
+            },
+            {
+              "relationName": "Parent: ADJP, Head: JJ, Child: RB",
+              "score": 1.0,
+              "srcConstituent": 175,
+              "targetConstituent": 176
+            },
+            {
+              "relationName": "Parent: VP, Head: VBN, Child: PP",
+              "score": 1.0,
+              "srcConstituent": 172,
+              "targetConstituent": 177
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 177,
+              "targetConstituent": 178
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: S",
+              "score": 1.0,
+              "srcConstituent": 171,
+              "targetConstituent": 179
+            },
+            {
+              "relationName": "Parent: VP, Head: VBD, Child: SBAR",
+              "score": 1.0,
+              "srcConstituent": 179,
+              "targetConstituent": 180
+            },
+            {
+              "relationName": "Parent: SBAR, Head: IN, Child: S",
+              "score": 1.0,
+              "srcConstituent": 180,
+              "targetConstituent": 181
+            },
+            {
+              "relationName": "Parent: VP, Head: VBP, Child: VP",
+              "score": 1.0,
+              "srcConstituent": 181,
+              "targetConstituent": 182
+            },
+            {
+              "relationName": "Parent: VP, Head: VBN, Child: ADVP",
+              "score": 1.0,
+              "srcConstituent": 182,
+              "targetConstituent": 183
+            },
+            {
+              "relationName": "Parent: VP, Head: VBN, Child: ADJP",
+              "score": 1.0,
+              "srcConstituent": 182,
+              "targetConstituent": 184
+            },
+            {
+              "relationName": "Parent: ADJP, Head: JJ, Child: PP",
+              "score": 1.0,
+              "srcConstituent": 184,
+              "targetConstituent": 185
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 185,
+              "targetConstituent": 186
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 181,
+              "targetConstituent": 187
+            },
+            {
+              "relationName": "Parent: NP, Head: NNS, Child: ``",
+              "score": 1.0,
+              "srcConstituent": 187,
+              "targetConstituent": 188
+            },
+            {
+              "relationName": "Parent: NP, Head: NNS, Child: JJ",
+              "score": 1.0,
+              "srcConstituent": 187,
+              "targetConstituent": 189
+            },
+            {
+              "relationName": "Parent: NP, Head: NNS, Child: \u0027\u0027",
+              "score": 1.0,
+              "srcConstituent": 187,
+              "targetConstituent": 190
+            },
+            {
+              "relationName": "Parent: NP, Head: NP, Child: PP",
+              "score": 1.0,
+              "srcConstituent": 187,
+              "targetConstituent": 191
+            },
+            {
+              "relationName": "Parent: PP, Head: IN, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 191,
+              "targetConstituent": 192
+            },
+            {
+              "relationName": "Parent: NP, Head: NN, Child: DT",
+              "score": 1.0,
+              "srcConstituent": 192,
+              "targetConstituent": 193
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 179,
+              "targetConstituent": 194
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: ,",
+              "score": 1.0,
+              "srcConstituent": 171,
+              "targetConstituent": 195
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: NP",
+              "score": 1.0,
+              "srcConstituent": 171,
+              "targetConstituent": 196
+            },
+            {
+              "relationName": "Parent: NP, Head: NN, Child: JJ",
+              "score": 1.0,
+              "srcConstituent": 196,
+              "targetConstituent": 197
+            },
+            {
+              "relationName": "Parent: S, Head: VP, Child: .",
+              "score": 1.0,
+              "srcConstituent": 171,
+              "targetConstituent": 198
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "viewName": "DEPENDENCY_STANFORD",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.TreeView",
+          "viewName": "DEPENDENCY_STANFORD",
+          "generator": "StanfordDepHandler",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "ROOT",
+              "start": 18,
+              "end": 19
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 0,
+              "end": 1
+            },
+            {
+              "label": "appos",
+              "score": 1.0,
+              "start": 4,
+              "end": 5
+            },
+            {
+              "label": "det",
+              "score": 1.0,
+              "start": 2,
+              "end": 3
+            },
+            {
+              "label": "nn",
+              "score": 1.0,
+              "start": 3,
+              "end": 4
+            },
+            {
+              "label": "rcmod",
+              "score": 1.0,
+              "start": 11,
+              "end": 12
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 6,
+              "end": 7
+            },
+            {
+              "label": "poss",
+              "score": 1.0,
+              "start": 5,
+              "end": 6
+            },
+            {
+              "label": "prep",
+              "score": 1.0,
+              "start": 7,
+              "end": 8
+            },
+            {
+              "label": "pobj",
+              "score": 1.0,
+              "start": 10,
+              "end": 11
+            },
+            {
+              "label": "det",
+              "score": 1.0,
+              "start": 8,
+              "end": 9
+            },
+            {
+              "label": "nn",
+              "score": 1.0,
+              "start": 9,
+              "end": 10
+            },
+            {
+              "label": "xcomp",
+              "score": 1.0,
+              "start": 12,
+              "end": 13
+            },
+            {
+              "label": "dobj",
+              "score": 1.0,
+              "start": 13,
+              "end": 14
+            },
+            {
+              "label": "prep",
+              "score": 1.0,
+              "start": 14,
+              "end": 15
+            },
+            {
+              "label": "pobj",
+              "score": 1.0,
+              "start": 16,
+              "end": 17
+            },
+            {
+              "label": "det",
+              "score": 1.0,
+              "start": 15,
+              "end": 16
+            },
+            {
+              "label": "tmod",
+              "score": 1.0,
+              "start": 19,
+              "end": 20
+            },
+            {
+              "label": "prep",
+              "score": 1.0,
+              "start": 20,
+              "end": 21
+            },
+            {
+              "label": "pobj",
+              "score": 1.0,
+              "start": 24,
+              "end": 25
+            },
+            {
+              "label": "poss",
+              "score": 1.0,
+              "start": 21,
+              "end": 22
+            },
+            {
+              "label": "possessive",
+              "score": 1.0,
+              "start": 22,
+              "end": 23
+            },
+            {
+              "label": "punct",
+              "score": 1.0,
+              "start": 23,
+              "end": 24
+            },
+            {
+              "label": "dep",
+              "score": 1.0,
+              "start": 25,
+              "end": 26
+            },
+            {
+              "label": "punct",
+              "score": 1.0,
+              "start": 26,
+              "end": 27
+            },
+            {
+              "label": "dep",
+              "score": 1.0,
+              "start": 30,
+              "end": 31
+            },
+            {
+              "label": "tmod",
+              "score": 1.0,
+              "start": 51,
+              "end": 52
+            },
+            {
+              "label": "amod",
+              "score": 1.0,
+              "start": 50,
+              "end": 51
+            },
+            {
+              "label": "ccomp",
+              "score": 1.0,
+              "start": 36,
+              "end": 37
+            },
+            {
+              "label": "aux",
+              "score": 1.0,
+              "start": 34,
+              "end": 35
+            },
+            {
+              "label": "neg",
+              "score": 1.0,
+              "start": 35,
+              "end": 36
+            },
+            {
+              "label": "advmod",
+              "score": 1.0,
+              "start": 37,
+              "end": 38
+            },
+            {
+              "label": "dobj",
+              "score": 1.0,
+              "start": 38,
+              "end": 39
+            },
+            {
+              "label": "prep",
+              "score": 1.0,
+              "start": 39,
+              "end": 40
+            },
+            {
+              "label": "pobj",
+              "score": 1.0,
+              "start": 43,
+              "end": 44
+            },
+            {
+              "label": "poss",
+              "score": 1.0,
+              "start": 41,
+              "end": 42
+            },
+            {
+              "label": "nn",
+              "score": 1.0,
+              "start": 40,
+              "end": 41
+            },
+            {
+              "label": "possessive",
+              "score": 1.0,
+              "start": 42,
+              "end": 43
+            },
+            {
+              "label": "prep",
+              "score": 1.0,
+              "start": 44,
+              "end": 45
+            },
+            {
+              "label": "pobj",
+              "score": 1.0,
+              "start": 49,
+              "end": 50
+            },
+            {
+              "label": "nn",
+              "score": 1.0,
+              "start": 48,
+              "end": 49
+            },
+            {
+              "label": "nn",
+              "score": 1.0,
+              "start": 45,
+              "end": 46
+            },
+            {
+              "label": "nn",
+              "score": 1.0,
+              "start": 46,
+              "end": 47
+            },
+            {
+              "label": "nn",
+              "score": 1.0,
+              "start": 47,
+              "end": 48
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 31,
+              "end": 32
+            },
+            {
+              "label": "prep",
+              "score": 1.0,
+              "start": 32,
+              "end": 33
+            },
+            {
+              "label": "pobj",
+              "score": 1.0,
+              "start": 33,
+              "end": 34
+            },
+            {
+              "label": "mark",
+              "score": 1.0,
+              "start": 27,
+              "end": 28
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 28,
+              "end": 29
+            },
+            {
+              "label": "cop",
+              "score": 1.0,
+              "start": 29,
+              "end": 30
+            },
+            {
+              "label": "ROOT",
+              "start": 57,
+              "end": 58
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 55,
+              "end": 56
+            },
+            {
+              "label": "poss",
+              "score": 1.0,
+              "start": 53,
+              "end": 54
+            },
+            {
+              "label": "possessive",
+              "score": 1.0,
+              "start": 54,
+              "end": 55
+            },
+            {
+              "label": "aux",
+              "score": 1.0,
+              "start": 56,
+              "end": 57
+            },
+            {
+              "label": "dobj",
+              "score": 1.0,
+              "start": 59,
+              "end": 60
+            },
+            {
+              "label": "amod",
+              "score": 1.0,
+              "start": 58,
+              "end": 59
+            },
+            {
+              "label": "prep",
+              "score": 1.0,
+              "start": 60,
+              "end": 61
+            },
+            {
+              "label": "pobj",
+              "score": 1.0,
+              "start": 63,
+              "end": 64
+            },
+            {
+              "label": "det",
+              "score": 1.0,
+              "start": 61,
+              "end": 62
+            },
+            {
+              "label": "nn",
+              "score": 1.0,
+              "start": 62,
+              "end": 63
+            },
+            {
+              "label": "cc",
+              "score": 1.0,
+              "start": 64,
+              "end": 65
+            },
+            {
+              "label": "conj",
+              "score": 1.0,
+              "start": 65,
+              "end": 66
+            },
+            {
+              "label": "ROOT",
+              "start": 67,
+              "end": 68
+            },
+            {
+              "label": "parataxis",
+              "score": 1.0,
+              "start": 78,
+              "end": 79
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 71,
+              "end": 72
+            },
+            {
+              "label": "prep",
+              "score": 1.0,
+              "start": 72,
+              "end": 73
+            },
+            {
+              "label": "pobj",
+              "score": 1.0,
+              "start": 73,
+              "end": 74
+            },
+            {
+              "label": "poss",
+              "score": 1.0,
+              "start": 69,
+              "end": 70
+            },
+            {
+              "label": "possessive",
+              "score": 1.0,
+              "start": 70,
+              "end": 71
+            },
+            {
+              "label": "advmod",
+              "score": 1.0,
+              "start": 76,
+              "end": 77
+            },
+            {
+              "label": "aux",
+              "score": 1.0,
+              "start": 77,
+              "end": 78
+            },
+            {
+              "label": "prep",
+              "score": 1.0,
+              "start": 79,
+              "end": 80
+            },
+            {
+              "label": "pobj",
+              "score": 1.0,
+              "start": 83,
+              "end": 84
+            },
+            {
+              "label": "rcmod",
+              "score": 1.0,
+              "start": 90,
+              "end": 91
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 86,
+              "end": 87
+            },
+            {
+              "label": "prep",
+              "score": 1.0,
+              "start": 87,
+              "end": 88
+            },
+            {
+              "label": "pobj",
+              "score": 1.0,
+              "start": 88,
+              "end": 89
+            },
+            {
+              "label": "det",
+              "score": 1.0,
+              "start": 85,
+              "end": 86
+            },
+            {
+              "label": "cop",
+              "score": 1.0,
+              "start": 89,
+              "end": 90
+            },
+            {
+              "label": "punct",
+              "score": 1.0,
+              "start": 84,
+              "end": 85
+            },
+            {
+              "label": "amod",
+              "score": 1.0,
+              "start": 81,
+              "end": 82
+            },
+            {
+              "label": "nn",
+              "score": 1.0,
+              "start": 82,
+              "end": 83
+            },
+            {
+              "label": "ROOT",
+              "start": 116,
+              "end": 117
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 115,
+              "end": 116
+            },
+            {
+              "label": "punct",
+              "score": 1.0,
+              "start": 114,
+              "end": 115
+            },
+            {
+              "label": "dep",
+              "score": 1.0,
+              "start": 101,
+              "end": 102
+            },
+            {
+              "label": "dep",
+              "score": 1.0,
+              "start": 95,
+              "end": 96
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 92,
+              "end": 93
+            },
+            {
+              "label": "cop",
+              "score": 1.0,
+              "start": 93,
+              "end": 94
+            },
+            {
+              "label": "det",
+              "score": 1.0,
+              "start": 94,
+              "end": 95
+            },
+            {
+              "label": "rcmod",
+              "score": 1.0,
+              "start": 97,
+              "end": 98
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 96,
+              "end": 97
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 100,
+              "end": 101
+            },
+            {
+              "label": "dep",
+              "score": 1.0,
+              "start": 104,
+              "end": 105
+            },
+            {
+              "label": "cc",
+              "score": 1.0,
+              "start": 106,
+              "end": 107
+            },
+            {
+              "label": "conj",
+              "score": 1.0,
+              "start": 108,
+              "end": 109
+            },
+            {
+              "label": "advmod",
+              "score": 1.0,
+              "start": 107,
+              "end": 108
+            },
+            {
+              "label": "ccomp",
+              "score": 1.0,
+              "start": 110,
+              "end": 111
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 109,
+              "end": 110
+            },
+            {
+              "label": "dobj",
+              "score": 1.0,
+              "start": 111,
+              "end": 112
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 103,
+              "end": 104
+            },
+            {
+              "label": "det",
+              "score": 1.0,
+              "start": 102,
+              "end": 103
+            },
+            {
+              "label": "ROOT",
+              "start": 119,
+              "end": 120
+            },
+            {
+              "label": "punct",
+              "score": 1.0,
+              "start": 141,
+              "end": 142
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 118,
+              "end": 119
+            },
+            {
+              "label": "ccomp",
+              "score": 1.0,
+              "start": 123,
+              "end": 124
+            },
+            {
+              "label": "cc",
+              "score": 1.0,
+              "start": 124,
+              "end": 125
+            },
+            {
+              "label": "conj",
+              "score": 1.0,
+              "start": 125,
+              "end": 126
+            },
+            {
+              "label": "dobj",
+              "score": 1.0,
+              "start": 127,
+              "end": 128
+            },
+            {
+              "label": "det",
+              "score": 1.0,
+              "start": 126,
+              "end": 127
+            },
+            {
+              "label": "prep",
+              "score": 1.0,
+              "start": 128,
+              "end": 129
+            },
+            {
+              "label": "pobj",
+              "score": 1.0,
+              "start": 129,
+              "end": 130
+            },
+            {
+              "label": "punct",
+              "score": 1.0,
+              "start": 130,
+              "end": 131
+            },
+            {
+              "label": "dep",
+              "score": 1.0,
+              "start": 134,
+              "end": 135
+            },
+            {
+              "label": "mark",
+              "score": 1.0,
+              "start": 131,
+              "end": 132
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 132,
+              "end": 133
+            },
+            {
+              "label": "cop",
+              "score": 1.0,
+              "start": 133,
+              "end": 134
+            },
+            {
+              "label": "xcomp",
+              "score": 1.0,
+              "start": 136,
+              "end": 137
+            },
+            {
+              "label": "aux",
+              "score": 1.0,
+              "start": 135,
+              "end": 136
+            },
+            {
+              "label": "ccomp",
+              "score": 1.0,
+              "start": 139,
+              "end": 140
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 138,
+              "end": 139
+            },
+            {
+              "label": "det",
+              "score": 1.0,
+              "start": 137,
+              "end": 138
+            },
+            {
+              "label": "mark",
+              "score": 1.0,
+              "start": 120,
+              "end": 121
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 122,
+              "end": 123
+            },
+            {
+              "label": "det",
+              "score": 1.0,
+              "start": 121,
+              "end": 122
+            },
+            {
+              "label": "ROOT",
+              "start": 143,
+              "end": 144
+            },
+            {
+              "label": "advcl",
+              "score": 1.0,
+              "start": 154,
+              "end": 155
+            },
+            {
+              "label": "mark",
+              "score": 1.0,
+              "start": 144,
+              "end": 145
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 146,
+              "end": 147
+            },
+            {
+              "label": "det",
+              "score": 1.0,
+              "start": 145,
+              "end": 146
+            },
+            {
+              "label": "prep",
+              "score": 1.0,
+              "start": 147,
+              "end": 148
+            },
+            {
+              "label": "pobj",
+              "score": 1.0,
+              "start": 152,
+              "end": 153
+            },
+            {
+              "label": "det",
+              "score": 1.0,
+              "start": 148,
+              "end": 149
+            },
+            {
+              "label": "nn",
+              "score": 1.0,
+              "start": 149,
+              "end": 150
+            },
+            {
+              "label": "nn",
+              "score": 1.0,
+              "start": 151,
+              "end": 152
+            },
+            {
+              "label": "aux",
+              "score": 1.0,
+              "start": 153,
+              "end": 154
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 142,
+              "end": 143
+            },
+            {
+              "label": "ROOT",
+              "start": 157,
+              "end": 158
+            },
+            {
+              "label": "ccomp",
+              "score": 1.0,
+              "start": 163,
+              "end": 164
+            },
+            {
+              "label": "punct",
+              "score": 1.0,
+              "start": 162,
+              "end": 163
+            },
+            {
+              "label": "amod",
+              "score": 1.0,
+              "start": 164,
+              "end": 165
+            },
+            {
+              "label": "punct",
+              "score": 1.0,
+              "start": 165,
+              "end": 166
+            },
+            {
+              "label": "prep",
+              "score": 1.0,
+              "start": 167,
+              "end": 168
+            },
+            {
+              "label": "advmod",
+              "score": 1.0,
+              "start": 166,
+              "end": 167
+            },
+            {
+              "label": "pobj",
+              "score": 1.0,
+              "start": 168,
+              "end": 169
+            },
+            {
+              "label": "tmod",
+              "score": 1.0,
+              "start": 169,
+              "end": 170
+            },
+            {
+              "label": "expl",
+              "score": 1.0,
+              "start": 158,
+              "end": 159
+            },
+            {
+              "label": "aux",
+              "score": 1.0,
+              "start": 159,
+              "end": 160
+            },
+            {
+              "label": "neg",
+              "score": 1.0,
+              "start": 160,
+              "end": 161
+            },
+            {
+              "label": "cop",
+              "score": 1.0,
+              "start": 161,
+              "end": 162
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 156,
+              "end": 157
+            },
+            {
+              "label": "ROOT",
+              "start": 193,
+              "end": 194
+            },
+            {
+              "label": "ccomp",
+              "score": 1.0,
+              "start": 172,
+              "end": 173
+            },
+            {
+              "label": "advcl",
+              "score": 1.0,
+              "start": 184,
+              "end": 185
+            },
+            {
+              "label": "aux",
+              "score": 1.0,
+              "start": 181,
+              "end": 182
+            },
+            {
+              "label": "cop",
+              "score": 1.0,
+              "start": 182,
+              "end": 183
+            },
+            {
+              "label": "advmod",
+              "score": 1.0,
+              "start": 183,
+              "end": 184
+            },
+            {
+              "label": "prep",
+              "score": 1.0,
+              "start": 185,
+              "end": 186
+            },
+            {
+              "label": "pobj",
+              "score": 1.0,
+              "start": 186,
+              "end": 187
+            },
+            {
+              "label": "mark",
+              "score": 1.0,
+              "start": 173,
+              "end": 174
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 177,
+              "end": 178
+            },
+            {
+              "label": "punct",
+              "score": 1.0,
+              "start": 174,
+              "end": 175
+            },
+            {
+              "label": "amod",
+              "score": 1.0,
+              "start": 175,
+              "end": 176
+            },
+            {
+              "label": "punct",
+              "score": 1.0,
+              "start": 176,
+              "end": 177
+            },
+            {
+              "label": "prep",
+              "score": 1.0,
+              "start": 178,
+              "end": 179
+            },
+            {
+              "label": "pobj",
+              "score": 1.0,
+              "start": 180,
+              "end": 181
+            },
+            {
+              "label": "det",
+              "score": 1.0,
+              "start": 179,
+              "end": 180
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 171,
+              "end": 172
+            },
+            {
+              "label": "nsubj",
+              "score": 1.0,
+              "start": 189,
+              "end": 190
+            },
+            {
+              "label": "amod",
+              "score": 1.0,
+              "start": 188,
+              "end": 189
+            },
+            {
+              "label": "aux",
+              "score": 1.0,
+              "start": 190,
+              "end": 191
+            },
+            {
+              "label": "cop",
+              "score": 1.0,
+              "start": 191,
+              "end": 192
+            },
+            {
+              "label": "advmod",
+              "score": 1.0,
+              "start": 192,
+              "end": 193
+            },
+            {
+              "label": "cc",
+              "score": 1.0,
+              "start": 194,
+              "end": 195
+            },
+            {
+              "label": "conj",
+              "score": 1.0,
+              "start": 195,
+              "end": 196
+            },
+            {
+              "label": "prep",
+              "score": 1.0,
+              "start": 196,
+              "end": 197
+            },
+            {
+              "label": "pobj",
+              "score": 1.0,
+              "start": 197,
+              "end": 198
+            }
+          ],
+          "relations": [
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 1
+            },
+            {
+              "relationName": "appos",
+              "score": 1.0,
+              "srcConstituent": 1,
+              "targetConstituent": 2
+            },
+            {
+              "relationName": "det",
+              "score": 1.0,
+              "srcConstituent": 2,
+              "targetConstituent": 3
+            },
+            {
+              "relationName": "nn",
+              "score": 1.0,
+              "srcConstituent": 2,
+              "targetConstituent": 4
+            },
+            {
+              "relationName": "rcmod",
+              "score": 1.0,
+              "srcConstituent": 2,
+              "targetConstituent": 5
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 5,
+              "targetConstituent": 6
+            },
+            {
+              "relationName": "poss",
+              "score": 1.0,
+              "srcConstituent": 6,
+              "targetConstituent": 7
+            },
+            {
+              "relationName": "prep",
+              "score": 1.0,
+              "srcConstituent": 6,
+              "targetConstituent": 8
+            },
+            {
+              "relationName": "pobj",
+              "score": 1.0,
+              "srcConstituent": 8,
+              "targetConstituent": 9
+            },
+            {
+              "relationName": "det",
+              "score": 1.0,
+              "srcConstituent": 9,
+              "targetConstituent": 10
+            },
+            {
+              "relationName": "nn",
+              "score": 1.0,
+              "srcConstituent": 9,
+              "targetConstituent": 11
+            },
+            {
+              "relationName": "xcomp",
+              "score": 1.0,
+              "srcConstituent": 5,
+              "targetConstituent": 12
+            },
+            {
+              "relationName": "dobj",
+              "score": 1.0,
+              "srcConstituent": 12,
+              "targetConstituent": 13
+            },
+            {
+              "relationName": "prep",
+              "score": 1.0,
+              "srcConstituent": 13,
+              "targetConstituent": 14
+            },
+            {
+              "relationName": "pobj",
+              "score": 1.0,
+              "srcConstituent": 14,
+              "targetConstituent": 15
+            },
+            {
+              "relationName": "det",
+              "score": 1.0,
+              "srcConstituent": 15,
+              "targetConstituent": 16
+            },
+            {
+              "relationName": "tmod",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 17
+            },
+            {
+              "relationName": "prep",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 18
+            },
+            {
+              "relationName": "pobj",
+              "score": 1.0,
+              "srcConstituent": 18,
+              "targetConstituent": 19
+            },
+            {
+              "relationName": "poss",
+              "score": 1.0,
+              "srcConstituent": 19,
+              "targetConstituent": 20
+            },
+            {
+              "relationName": "possessive",
+              "score": 1.0,
+              "srcConstituent": 20,
+              "targetConstituent": 21
+            },
+            {
+              "relationName": "punct",
+              "score": 1.0,
+              "srcConstituent": 19,
+              "targetConstituent": 22
+            },
+            {
+              "relationName": "dep",
+              "score": 1.0,
+              "srcConstituent": 18,
+              "targetConstituent": 23
+            },
+            {
+              "relationName": "punct",
+              "score": 1.0,
+              "srcConstituent": 23,
+              "targetConstituent": 24
+            },
+            {
+              "relationName": "dep",
+              "score": 1.0,
+              "srcConstituent": 23,
+              "targetConstituent": 25
+            },
+            {
+              "relationName": "tmod",
+              "score": 1.0,
+              "srcConstituent": 25,
+              "targetConstituent": 26
+            },
+            {
+              "relationName": "amod",
+              "score": 1.0,
+              "srcConstituent": 26,
+              "targetConstituent": 27
+            },
+            {
+              "relationName": "ccomp",
+              "score": 1.0,
+              "srcConstituent": 25,
+              "targetConstituent": 28
+            },
+            {
+              "relationName": "aux",
+              "score": 1.0,
+              "srcConstituent": 28,
+              "targetConstituent": 29
+            },
+            {
+              "relationName": "neg",
+              "score": 1.0,
+              "srcConstituent": 28,
+              "targetConstituent": 30
+            },
+            {
+              "relationName": "advmod",
+              "score": 1.0,
+              "srcConstituent": 28,
+              "targetConstituent": 31
+            },
+            {
+              "relationName": "dobj",
+              "score": 1.0,
+              "srcConstituent": 28,
+              "targetConstituent": 32
+            },
+            {
+              "relationName": "prep",
+              "score": 1.0,
+              "srcConstituent": 32,
+              "targetConstituent": 33
+            },
+            {
+              "relationName": "pobj",
+              "score": 1.0,
+              "srcConstituent": 33,
+              "targetConstituent": 34
+            },
+            {
+              "relationName": "poss",
+              "score": 1.0,
+              "srcConstituent": 34,
+              "targetConstituent": 35
+            },
+            {
+              "relationName": "nn",
+              "score": 1.0,
+              "srcConstituent": 35,
+              "targetConstituent": 36
+            },
+            {
+              "relationName": "possessive",
+              "score": 1.0,
+              "srcConstituent": 35,
+              "targetConstituent": 37
+            },
+            {
+              "relationName": "prep",
+              "score": 1.0,
+              "srcConstituent": 28,
+              "targetConstituent": 38
+            },
+            {
+              "relationName": "pobj",
+              "score": 1.0,
+              "srcConstituent": 38,
+              "targetConstituent": 39
+            },
+            {
+              "relationName": "nn",
+              "score": 1.0,
+              "srcConstituent": 39,
+              "targetConstituent": 40
+            },
+            {
+              "relationName": "nn",
+              "score": 1.0,
+              "srcConstituent": 39,
+              "targetConstituent": 41
+            },
+            {
+              "relationName": "nn",
+              "score": 1.0,
+              "srcConstituent": 39,
+              "targetConstituent": 42
+            },
+            {
+              "relationName": "nn",
+              "score": 1.0,
+              "srcConstituent": 39,
+              "targetConstituent": 43
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 28,
+              "targetConstituent": 44
+            },
+            {
+              "relationName": "prep",
+              "score": 1.0,
+              "srcConstituent": 44,
+              "targetConstituent": 45
+            },
+            {
+              "relationName": "pobj",
+              "score": 1.0,
+              "srcConstituent": 45,
+              "targetConstituent": 46
+            },
+            {
+              "relationName": "mark",
+              "score": 1.0,
+              "srcConstituent": 25,
+              "targetConstituent": 47
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 25,
+              "targetConstituent": 48
+            },
+            {
+              "relationName": "cop",
+              "score": 1.0,
+              "srcConstituent": 25,
+              "targetConstituent": 49
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 50,
+              "targetConstituent": 51
+            },
+            {
+              "relationName": "poss",
+              "score": 1.0,
+              "srcConstituent": 51,
+              "targetConstituent": 52
+            },
+            {
+              "relationName": "possessive",
+              "score": 1.0,
+              "srcConstituent": 52,
+              "targetConstituent": 53
+            },
+            {
+              "relationName": "aux",
+              "score": 1.0,
+              "srcConstituent": 50,
+              "targetConstituent": 54
+            },
+            {
+              "relationName": "dobj",
+              "score": 1.0,
+              "srcConstituent": 50,
+              "targetConstituent": 55
+            },
+            {
+              "relationName": "amod",
+              "score": 1.0,
+              "srcConstituent": 55,
+              "targetConstituent": 56
+            },
+            {
+              "relationName": "prep",
+              "score": 1.0,
+              "srcConstituent": 55,
+              "targetConstituent": 57
+            },
+            {
+              "relationName": "pobj",
+              "score": 1.0,
+              "srcConstituent": 57,
+              "targetConstituent": 58
+            },
+            {
+              "relationName": "det",
+              "score": 1.0,
+              "srcConstituent": 58,
+              "targetConstituent": 59
+            },
+            {
+              "relationName": "nn",
+              "score": 1.0,
+              "srcConstituent": 58,
+              "targetConstituent": 60
+            },
+            {
+              "relationName": "cc",
+              "score": 1.0,
+              "srcConstituent": 58,
+              "targetConstituent": 61
+            },
+            {
+              "relationName": "conj",
+              "score": 1.0,
+              "srcConstituent": 58,
+              "targetConstituent": 62
+            },
+            {
+              "relationName": "parataxis",
+              "score": 1.0,
+              "srcConstituent": 63,
+              "targetConstituent": 64
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 64,
+              "targetConstituent": 65
+            },
+            {
+              "relationName": "prep",
+              "score": 1.0,
+              "srcConstituent": 65,
+              "targetConstituent": 66
+            },
+            {
+              "relationName": "pobj",
+              "score": 1.0,
+              "srcConstituent": 66,
+              "targetConstituent": 67
+            },
+            {
+              "relationName": "poss",
+              "score": 1.0,
+              "srcConstituent": 65,
+              "targetConstituent": 68
+            },
+            {
+              "relationName": "possessive",
+              "score": 1.0,
+              "srcConstituent": 68,
+              "targetConstituent": 69
+            },
+            {
+              "relationName": "advmod",
+              "score": 1.0,
+              "srcConstituent": 64,
+              "targetConstituent": 70
+            },
+            {
+              "relationName": "aux",
+              "score": 1.0,
+              "srcConstituent": 64,
+              "targetConstituent": 71
+            },
+            {
+              "relationName": "prep",
+              "score": 1.0,
+              "srcConstituent": 64,
+              "targetConstituent": 72
+            },
+            {
+              "relationName": "pobj",
+              "score": 1.0,
+              "srcConstituent": 72,
+              "targetConstituent": 73
+            },
+            {
+              "relationName": "rcmod",
+              "score": 1.0,
+              "srcConstituent": 73,
+              "targetConstituent": 74
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 74,
+              "targetConstituent": 75
+            },
+            {
+              "relationName": "prep",
+              "score": 1.0,
+              "srcConstituent": 75,
+              "targetConstituent": 76
+            },
+            {
+              "relationName": "pobj",
+              "score": 1.0,
+              "srcConstituent": 76,
+              "targetConstituent": 77
+            },
+            {
+              "relationName": "det",
+              "score": 1.0,
+              "srcConstituent": 75,
+              "targetConstituent": 78
+            },
+            {
+              "relationName": "cop",
+              "score": 1.0,
+              "srcConstituent": 74,
+              "targetConstituent": 79
+            },
+            {
+              "relationName": "punct",
+              "score": 1.0,
+              "srcConstituent": 74,
+              "targetConstituent": 80
+            },
+            {
+              "relationName": "amod",
+              "score": 1.0,
+              "srcConstituent": 73,
+              "targetConstituent": 81
+            },
+            {
+              "relationName": "nn",
+              "score": 1.0,
+              "srcConstituent": 73,
+              "targetConstituent": 82
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 83,
+              "targetConstituent": 84
+            },
+            {
+              "relationName": "punct",
+              "score": 1.0,
+              "srcConstituent": 84,
+              "targetConstituent": 85
+            },
+            {
+              "relationName": "dep",
+              "score": 1.0,
+              "srcConstituent": 83,
+              "targetConstituent": 86
+            },
+            {
+              "relationName": "dep",
+              "score": 1.0,
+              "srcConstituent": 86,
+              "targetConstituent": 87
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 87,
+              "targetConstituent": 88
+            },
+            {
+              "relationName": "cop",
+              "score": 1.0,
+              "srcConstituent": 87,
+              "targetConstituent": 89
+            },
+            {
+              "relationName": "det",
+              "score": 1.0,
+              "srcConstituent": 87,
+              "targetConstituent": 90
+            },
+            {
+              "relationName": "rcmod",
+              "score": 1.0,
+              "srcConstituent": 87,
+              "targetConstituent": 91
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 91,
+              "targetConstituent": 92
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 86,
+              "targetConstituent": 93
+            },
+            {
+              "relationName": "dep",
+              "score": 1.0,
+              "srcConstituent": 86,
+              "targetConstituent": 94
+            },
+            {
+              "relationName": "cc",
+              "score": 1.0,
+              "srcConstituent": 94,
+              "targetConstituent": 95
+            },
+            {
+              "relationName": "conj",
+              "score": 1.0,
+              "srcConstituent": 94,
+              "targetConstituent": 96
+            },
+            {
+              "relationName": "advmod",
+              "score": 1.0,
+              "srcConstituent": 96,
+              "targetConstituent": 97
+            },
+            {
+              "relationName": "ccomp",
+              "score": 1.0,
+              "srcConstituent": 96,
+              "targetConstituent": 98
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 98,
+              "targetConstituent": 99
+            },
+            {
+              "relationName": "dobj",
+              "score": 1.0,
+              "srcConstituent": 98,
+              "targetConstituent": 100
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 94,
+              "targetConstituent": 101
+            },
+            {
+              "relationName": "det",
+              "score": 1.0,
+              "srcConstituent": 101,
+              "targetConstituent": 102
+            },
+            {
+              "relationName": "punct",
+              "score": 1.0,
+              "srcConstituent": 103,
+              "targetConstituent": 104
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 103,
+              "targetConstituent": 105
+            },
+            {
+              "relationName": "ccomp",
+              "score": 1.0,
+              "srcConstituent": 103,
+              "targetConstituent": 106
+            },
+            {
+              "relationName": "cc",
+              "score": 1.0,
+              "srcConstituent": 106,
+              "targetConstituent": 107
+            },
+            {
+              "relationName": "conj",
+              "score": 1.0,
+              "srcConstituent": 106,
+              "targetConstituent": 108
+            },
+            {
+              "relationName": "dobj",
+              "score": 1.0,
+              "srcConstituent": 106,
+              "targetConstituent": 109
+            },
+            {
+              "relationName": "det",
+              "score": 1.0,
+              "srcConstituent": 109,
+              "targetConstituent": 110
+            },
+            {
+              "relationName": "prep",
+              "score": 1.0,
+              "srcConstituent": 109,
+              "targetConstituent": 111
+            },
+            {
+              "relationName": "pobj",
+              "score": 1.0,
+              "srcConstituent": 111,
+              "targetConstituent": 112
+            },
+            {
+              "relationName": "punct",
+              "score": 1.0,
+              "srcConstituent": 112,
+              "targetConstituent": 113
+            },
+            {
+              "relationName": "dep",
+              "score": 1.0,
+              "srcConstituent": 112,
+              "targetConstituent": 114
+            },
+            {
+              "relationName": "mark",
+              "score": 1.0,
+              "srcConstituent": 114,
+              "targetConstituent": 115
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 114,
+              "targetConstituent": 116
+            },
+            {
+              "relationName": "cop",
+              "score": 1.0,
+              "srcConstituent": 114,
+              "targetConstituent": 117
+            },
+            {
+              "relationName": "xcomp",
+              "score": 1.0,
+              "srcConstituent": 114,
+              "targetConstituent": 118
+            },
+            {
+              "relationName": "aux",
+              "score": 1.0,
+              "srcConstituent": 118,
+              "targetConstituent": 119
+            },
+            {
+              "relationName": "ccomp",
+              "score": 1.0,
+              "srcConstituent": 118,
+              "targetConstituent": 120
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 120,
+              "targetConstituent": 121
+            },
+            {
+              "relationName": "det",
+              "score": 1.0,
+              "srcConstituent": 121,
+              "targetConstituent": 122
+            },
+            {
+              "relationName": "mark",
+              "score": 1.0,
+              "srcConstituent": 106,
+              "targetConstituent": 123
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 106,
+              "targetConstituent": 124
+            },
+            {
+              "relationName": "det",
+              "score": 1.0,
+              "srcConstituent": 124,
+              "targetConstituent": 125
+            },
+            {
+              "relationName": "advcl",
+              "score": 1.0,
+              "srcConstituent": 126,
+              "targetConstituent": 127
+            },
+            {
+              "relationName": "mark",
+              "score": 1.0,
+              "srcConstituent": 127,
+              "targetConstituent": 128
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 127,
+              "targetConstituent": 129
+            },
+            {
+              "relationName": "det",
+              "score": 1.0,
+              "srcConstituent": 129,
+              "targetConstituent": 130
+            },
+            {
+              "relationName": "prep",
+              "score": 1.0,
+              "srcConstituent": 129,
+              "targetConstituent": 131
+            },
+            {
+              "relationName": "pobj",
+              "score": 1.0,
+              "srcConstituent": 131,
+              "targetConstituent": 132
+            },
+            {
+              "relationName": "det",
+              "score": 1.0,
+              "srcConstituent": 132,
+              "targetConstituent": 133
+            },
+            {
+              "relationName": "nn",
+              "score": 1.0,
+              "srcConstituent": 132,
+              "targetConstituent": 134
+            },
+            {
+              "relationName": "nn",
+              "score": 1.0,
+              "srcConstituent": 132,
+              "targetConstituent": 135
+            },
+            {
+              "relationName": "aux",
+              "score": 1.0,
+              "srcConstituent": 127,
+              "targetConstituent": 136
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 126,
+              "targetConstituent": 137
+            },
+            {
+              "relationName": "ccomp",
+              "score": 1.0,
+              "srcConstituent": 138,
+              "targetConstituent": 139
+            },
+            {
+              "relationName": "punct",
+              "score": 1.0,
+              "srcConstituent": 139,
+              "targetConstituent": 140
+            },
+            {
+              "relationName": "amod",
+              "score": 1.0,
+              "srcConstituent": 139,
+              "targetConstituent": 141
+            },
+            {
+              "relationName": "punct",
+              "score": 1.0,
+              "srcConstituent": 139,
+              "targetConstituent": 142
+            },
+            {
+              "relationName": "prep",
+              "score": 1.0,
+              "srcConstituent": 139,
+              "targetConstituent": 143
+            },
+            {
+              "relationName": "advmod",
+              "score": 1.0,
+              "srcConstituent": 143,
+              "targetConstituent": 144
+            },
+            {
+              "relationName": "pobj",
+              "score": 1.0,
+              "srcConstituent": 143,
+              "targetConstituent": 145
+            },
+            {
+              "relationName": "tmod",
+              "score": 1.0,
+              "srcConstituent": 139,
+              "targetConstituent": 146
+            },
+            {
+              "relationName": "expl",
+              "score": 1.0,
+              "srcConstituent": 139,
+              "targetConstituent": 147
+            },
+            {
+              "relationName": "aux",
+              "score": 1.0,
+              "srcConstituent": 139,
+              "targetConstituent": 148
+            },
+            {
+              "relationName": "neg",
+              "score": 1.0,
+              "srcConstituent": 139,
+              "targetConstituent": 149
+            },
+            {
+              "relationName": "cop",
+              "score": 1.0,
+              "srcConstituent": 139,
+              "targetConstituent": 150
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 138,
+              "targetConstituent": 151
+            },
+            {
+              "relationName": "ccomp",
+              "score": 1.0,
+              "srcConstituent": 152,
+              "targetConstituent": 153
+            },
+            {
+              "relationName": "advcl",
+              "score": 1.0,
+              "srcConstituent": 153,
+              "targetConstituent": 154
+            },
+            {
+              "relationName": "aux",
+              "score": 1.0,
+              "srcConstituent": 154,
+              "targetConstituent": 155
+            },
+            {
+              "relationName": "cop",
+              "score": 1.0,
+              "srcConstituent": 154,
+              "targetConstituent": 156
+            },
+            {
+              "relationName": "advmod",
+              "score": 1.0,
+              "srcConstituent": 154,
+              "targetConstituent": 157
+            },
+            {
+              "relationName": "prep",
+              "score": 1.0,
+              "srcConstituent": 154,
+              "targetConstituent": 158
+            },
+            {
+              "relationName": "pobj",
+              "score": 1.0,
+              "srcConstituent": 158,
+              "targetConstituent": 159
+            },
+            {
+              "relationName": "mark",
+              "score": 1.0,
+              "srcConstituent": 154,
+              "targetConstituent": 160
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 154,
+              "targetConstituent": 161
+            },
+            {
+              "relationName": "punct",
+              "score": 1.0,
+              "srcConstituent": 161,
+              "targetConstituent": 162
+            },
+            {
+              "relationName": "amod",
+              "score": 1.0,
+              "srcConstituent": 161,
+              "targetConstituent": 163
+            },
+            {
+              "relationName": "punct",
+              "score": 1.0,
+              "srcConstituent": 161,
+              "targetConstituent": 164
+            },
+            {
+              "relationName": "prep",
+              "score": 1.0,
+              "srcConstituent": 161,
+              "targetConstituent": 165
+            },
+            {
+              "relationName": "pobj",
+              "score": 1.0,
+              "srcConstituent": 165,
+              "targetConstituent": 166
+            },
+            {
+              "relationName": "det",
+              "score": 1.0,
+              "srcConstituent": 166,
+              "targetConstituent": 167
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 153,
+              "targetConstituent": 168
+            },
+            {
+              "relationName": "nsubj",
+              "score": 1.0,
+              "srcConstituent": 152,
+              "targetConstituent": 169
+            },
+            {
+              "relationName": "amod",
+              "score": 1.0,
+              "srcConstituent": 169,
+              "targetConstituent": 170
+            },
+            {
+              "relationName": "aux",
+              "score": 1.0,
+              "srcConstituent": 152,
+              "targetConstituent": 171
+            },
+            {
+              "relationName": "cop",
+              "score": 1.0,
+              "srcConstituent": 152,
+              "targetConstituent": 172
+            },
+            {
+              "relationName": "advmod",
+              "score": 1.0,
+              "srcConstituent": 152,
+              "targetConstituent": 173
+            },
+            {
+              "relationName": "cc",
+              "score": 1.0,
+              "srcConstituent": 152,
+              "targetConstituent": 174
+            },
+            {
+              "relationName": "conj",
+              "score": 1.0,
+              "srcConstituent": 152,
+              "targetConstituent": 175
+            },
+            {
+              "relationName": "prep",
+              "score": 1.0,
+              "srcConstituent": 152,
+              "targetConstituent": 176
+            },
+            {
+              "relationName": "pobj",
+              "score": 1.0,
+              "srcConstituent": 176,
+              "targetConstituent": 177
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "viewName": "HeuristicPredicateView:Nom",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.View",
+          "viewName": "HeuristicPredicateView:Nom",
+          "generator": "",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 4,
+              "end": 5,
+              "properties": {
+                "predicate": "contributor"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 6,
+              "end": 7,
+              "properties": {
+                "predicate": "reporting"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 10,
+              "end": 11,
+              "properties": {
+                "predicate": "post"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 25,
+              "end": 26,
+              "properties": {
+                "predicate": "source"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 33,
+              "end": 34,
+              "properties": {
+                "predicate": "congress"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 38,
+              "end": 39,
+              "properties": {
+                "predicate": "skepticism"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 40,
+              "end": 41,
+              "properties": {
+                "predicate": "president"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 43,
+              "end": 44,
+              "properties": {
+                "predicate": "decision"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 47,
+              "end": 48,
+              "properties": {
+                "predicate": "director"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 51,
+              "end": 52,
+              "properties": {
+                "predicate": "week"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 55,
+              "end": 56,
+              "properties": {
+                "predicate": "department"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 59,
+              "end": 60,
+              "properties": {
+                "predicate": "tie"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 63,
+              "end": 64,
+              "properties": {
+                "predicate": "campaign"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 71,
+              "end": 72,
+              "properties": {
+                "predicate": "chief"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 73,
+              "end": 74,
+              "properties": {
+                "predicate": "staff"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 82,
+              "end": 83,
+              "properties": {
+                "predicate": "libel"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 83,
+              "end": 84,
+              "properties": {
+                "predicate": "law"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 103,
+              "end": 104,
+              "properties": {
+                "predicate": "president"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 127,
+              "end": 128,
+              "properties": {
+                "predicate": "impeachment"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 138,
+              "end": 139,
+              "properties": {
+                "predicate": "truth"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 146,
+              "end": 147,
+              "properties": {
+                "predicate": "trial"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 177,
+              "end": 178,
+              "properties": {
+                "predicate": "member"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 180,
+              "end": 181,
+              "properties": {
+                "predicate": "party"
+              }
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 189,
+              "end": 190,
+              "properties": {
+                "predicate": "leadership"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "viewName": "LEMMA",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.TokenLabelView",
+          "viewName": "LEMMA",
+          "generator": "edu.illinois.cs.cogcomp.nlp.lemmatizer.IllinoisLemmatizer",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "bernstein",
+              "score": 1.0,
+              "start": 0,
+              "end": 1
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 1,
+              "end": 2
+            },
+            {
+              "label": "a",
+              "score": 1.0,
+              "start": 2,
+              "end": 3
+            },
+            {
+              "label": "cnn",
+              "score": 1.0,
+              "start": 3,
+              "end": 4
+            },
+            {
+              "label": "contributor",
+              "score": 1.0,
+              "start": 4,
+              "end": 5
+            },
+            {
+              "label": "whose",
+              "score": 1.0,
+              "start": 5,
+              "end": 6
+            },
+            {
+              "label": "reporting",
+              "score": 1.0,
+              "start": 6,
+              "end": 7
+            },
+            {
+              "label": "for",
+              "score": 1.0,
+              "start": 7,
+              "end": 8
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 8,
+              "end": 9
+            },
+            {
+              "label": "washington",
+              "score": 1.0,
+              "start": 9,
+              "end": 10
+            },
+            {
+              "label": "post",
+              "score": 1.0,
+              "start": 10,
+              "end": 11
+            },
+            {
+              "label": "help",
+              "score": 1.0,
+              "start": 11,
+              "end": 12
+            },
+            {
+              "label": "topple",
+              "score": 1.0,
+              "start": 12,
+              "end": 13
+            },
+            {
+              "label": "nixon",
+              "score": 1.0,
+              "start": 13,
+              "end": 14
+            },
+            {
+              "label": "in",
+              "score": 1.0,
+              "start": 14,
+              "end": 15
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 15,
+              "end": 16
+            },
+            {
+              "label": "1970s",
+              "score": 1.0,
+              "start": 16,
+              "end": 17
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 17,
+              "end": 18
+            },
+            {
+              "label": "say",
+              "score": 1.0,
+              "start": 18,
+              "end": 19
+            },
+            {
+              "label": "sunday",
+              "score": 1.0,
+              "start": 19,
+              "end": 20
+            },
+            {
+              "label": "on",
+              "score": 1.0,
+              "start": 20,
+              "end": 21
+            },
+            {
+              "label": "cnn",
+              "score": 1.0,
+              "start": 21,
+              "end": 22
+            },
+            {
+              "label": "\u0027s",
+              "score": 1.0,
+              "start": 22,
+              "end": 23
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 23,
+              "end": 24
+            },
+            {
+              "label": "reliable",
+              "score": 1.0,
+              "start": 24,
+              "end": 25
+            },
+            {
+              "label": "source",
+              "score": 1.0,
+              "start": 25,
+              "end": 26
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 26,
+              "end": 27
+            },
+            {
+              "label": "that",
+              "score": 1.0,
+              "start": 27,
+              "end": 28
+            },
+            {
+              "label": "he",
+              "score": 1.0,
+              "start": 28,
+              "end": 29
+            },
+            {
+              "label": "be",
+              "score": 1.0,
+              "start": 29,
+              "end": 30
+            },
+            {
+              "label": "concern",
+              "score": 1.0,
+              "start": 30,
+              "end": 31
+            },
+            {
+              "label": "republicans",
+              "score": 1.0,
+              "start": 31,
+              "end": 32
+            },
+            {
+              "label": "in",
+              "score": 1.0,
+              "start": 32,
+              "end": 33
+            },
+            {
+              "label": "congress",
+              "score": 1.0,
+              "start": 33,
+              "end": 34
+            },
+            {
+              "label": "have",
+              "score": 1.0,
+              "start": 34,
+              "end": 35
+            },
+            {
+              "label": "n\u0027t",
+              "score": 1.0,
+              "start": 35,
+              "end": 36
+            },
+            {
+              "label": "voice",
+              "score": 1.0,
+              "start": 36,
+              "end": 37
+            },
+            {
+              "label": "more",
+              "score": 1.0,
+              "start": 37,
+              "end": 38
+            },
+            {
+              "label": "skepticism",
+              "score": 1.0,
+              "start": 38,
+              "end": 39
+            },
+            {
+              "label": "of",
+              "score": 1.0,
+              "start": 39,
+              "end": 40
+            },
+            {
+              "label": "president",
+              "score": 1.0,
+              "start": 40,
+              "end": 41
+            },
+            {
+              "label": "trump",
+              "score": 1.0,
+              "start": 41,
+              "end": 42
+            },
+            {
+              "label": "\u0027s",
+              "score": 1.0,
+              "start": 42,
+              "end": 43
+            },
+            {
+              "label": "decision",
+              "score": 1.0,
+              "start": 43,
+              "end": 44
+            },
+            {
+              "label": "to",
+              "score": 1.0,
+              "start": 44,
+              "end": 45
+            },
+            {
+              "label": "fire",
+              "score": 1.0,
+              "start": 45,
+              "end": 46
+            },
+            {
+              "label": "fbi",
+              "score": 1.0,
+              "start": 46,
+              "end": 47
+            },
+            {
+              "label": "director",
+              "score": 1.0,
+              "start": 47,
+              "end": 48
+            },
+            {
+              "label": "james",
+              "score": 1.0,
+              "start": 48,
+              "end": 49
+            },
+            {
+              "label": "comey",
+              "score": 1.0,
+              "start": 49,
+              "end": 50
+            },
+            {
+              "label": "last",
+              "score": 1.0,
+              "start": 50,
+              "end": 51
+            },
+            {
+              "label": "week",
+              "score": 1.0,
+              "start": 51,
+              "end": 52
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 52,
+              "end": 53
+            },
+            {
+              "label": "comey",
+              "score": 1.0,
+              "start": 53,
+              "end": 54
+            },
+            {
+              "label": "\u0027s",
+              "score": 1.0,
+              "start": 54,
+              "end": 55
+            },
+            {
+              "label": "department",
+              "score": 1.0,
+              "start": 55,
+              "end": 56
+            },
+            {
+              "label": "be",
+              "score": 1.0,
+              "start": 56,
+              "end": 57
+            },
+            {
+              "label": "investigate",
+              "score": 1.0,
+              "start": 57,
+              "end": 58
+            },
+            {
+              "label": "potential",
+              "score": 1.0,
+              "start": 58,
+              "end": 59
+            },
+            {
+              "label": "tie",
+              "score": 1.0,
+              "start": 59,
+              "end": 60
+            },
+            {
+              "label": "between",
+              "score": 1.0,
+              "start": 60,
+              "end": 61
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 61,
+              "end": 62
+            },
+            {
+              "label": "trump",
+              "score": 1.0,
+              "start": 62,
+              "end": 63
+            },
+            {
+              "label": "campaign",
+              "score": 1.0,
+              "start": 63,
+              "end": 64
+            },
+            {
+              "label": "and",
+              "score": 1.0,
+              "start": 64,
+              "end": 65
+            },
+            {
+              "label": "russia",
+              "score": 1.0,
+              "start": 65,
+              "end": 66
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 66,
+              "end": 67
+            },
+            {
+              "label": "relate",
+              "score": 1.0,
+              "start": 67,
+              "end": 68
+            },
+            {
+              "label": ":",
+              "score": 1.0,
+              "start": 68,
+              "end": 69
+            },
+            {
+              "label": "trump",
+              "score": 1.0,
+              "start": 69,
+              "end": 70
+            },
+            {
+              "label": "\u0027s",
+              "score": 1.0,
+              "start": 70,
+              "end": 71
+            },
+            {
+              "label": "chief",
+              "score": 1.0,
+              "start": 71,
+              "end": 72
+            },
+            {
+              "label": "of",
+              "score": 1.0,
+              "start": 72,
+              "end": 73
+            },
+            {
+              "label": "staff",
+              "score": 1.0,
+              "start": 73,
+              "end": 74
+            },
+            {
+              "label": ":",
+              "score": 1.0,
+              "start": 74,
+              "end": 75
+            },
+            {
+              "label": "\u0027",
+              "score": 1.0,
+              "start": 75,
+              "end": 76
+            },
+            {
+              "label": "we",
+              "score": 1.0,
+              "start": 76,
+              "end": 77
+            },
+            {
+              "label": "have",
+              "score": 1.0,
+              "start": 77,
+              "end": 78
+            },
+            {
+              "label": "look",
+              "score": 1.0,
+              "start": 78,
+              "end": 79
+            },
+            {
+              "label": "at",
+              "score": 1.0,
+              "start": 79,
+              "end": 80
+            },
+            {
+              "label": "\u0027",
+              "score": 1.0,
+              "start": 80,
+              "end": 81
+            },
+            {
+              "label": "change",
+              "score": 1.0,
+              "start": 81,
+              "end": 82
+            },
+            {
+              "label": "libel",
+              "score": 1.0,
+              "start": 82,
+              "end": 83
+            },
+            {
+              "label": "law",
+              "score": 1.0,
+              "start": 83,
+              "end": 84
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 84,
+              "end": 85
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 85,
+              "end": 86
+            },
+            {
+              "label": "republicans",
+              "score": 1.0,
+              "start": 86,
+              "end": 87
+            },
+            {
+              "label": "during",
+              "score": 1.0,
+              "start": 87,
+              "end": 88
+            },
+            {
+              "label": "watergate",
+              "score": 1.0,
+              "start": 88,
+              "end": 89
+            },
+            {
+              "label": "be",
+              "score": 1.0,
+              "start": 89,
+              "end": 90
+            },
+            {
+              "label": "heroic",
+              "score": 1.0,
+              "start": 90,
+              "end": 91
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 91,
+              "end": 92
+            },
+            {
+              "label": "they",
+              "score": 1.0,
+              "start": 92,
+              "end": 93
+            },
+            {
+              "label": "be",
+              "score": 1.0,
+              "start": 93,
+              "end": 94
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 94,
+              "end": 95
+            },
+            {
+              "label": "one",
+              "score": 1.0,
+              "start": 95,
+              "end": 96
+            },
+            {
+              "label": "who",
+              "score": 1.0,
+              "start": 96,
+              "end": 97
+            },
+            {
+              "label": "say",
+              "score": 1.0,
+              "start": 97,
+              "end": 98
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 98,
+              "end": 99
+            },
+            {
+              "label": "\u0027",
+              "score": 1.0,
+              "start": 99,
+              "end": 100
+            },
+            {
+              "label": "what",
+              "score": 1.0,
+              "start": 100,
+              "end": 101
+            },
+            {
+              "label": "do",
+              "score": 1.0,
+              "start": 101,
+              "end": 102
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 102,
+              "end": 103
+            },
+            {
+              "label": "president",
+              "score": 1.0,
+              "start": 103,
+              "end": 104
+            },
+            {
+              "label": "know",
+              "score": 1.0,
+              "start": 104,
+              "end": 105
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 105,
+              "end": 106
+            },
+            {
+              "label": "and",
+              "score": 1.0,
+              "start": 106,
+              "end": 107
+            },
+            {
+              "label": "when",
+              "score": 1.0,
+              "start": 107,
+              "end": 108
+            },
+            {
+              "label": "do",
+              "score": 1.0,
+              "start": 108,
+              "end": 109
+            },
+            {
+              "label": "he",
+              "score": 1.0,
+              "start": 109,
+              "end": 110
+            },
+            {
+              "label": "know",
+              "score": 1.0,
+              "start": 110,
+              "end": 111
+            },
+            {
+              "label": "it",
+              "score": 1.0,
+              "start": 111,
+              "end": 112
+            },
+            {
+              "label": "?",
+              "score": 1.0,
+              "start": 112,
+              "end": 113
+            },
+            {
+              "label": "\u0027",
+              "score": 1.0,
+              "start": 113,
+              "end": 114
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 114,
+              "end": 115
+            },
+            {
+              "label": "bernstein",
+              "score": 1.0,
+              "start": 115,
+              "end": 116
+            },
+            {
+              "label": "say",
+              "score": 1.0,
+              "start": 116,
+              "end": 117
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 117,
+              "end": 118
+            },
+            {
+              "label": "he",
+              "score": 1.0,
+              "start": 118,
+              "end": 119
+            },
+            {
+              "label": "add",
+              "score": 1.0,
+              "start": 119,
+              "end": 120
+            },
+            {
+              "label": "that",
+              "score": 1.0,
+              "start": 120,
+              "end": 121
+            },
+            {
+              "label": "those",
+              "score": 1.0,
+              "start": 121,
+              "end": 122
+            },
+            {
+              "label": "republicans",
+              "score": 1.0,
+              "start": 122,
+              "end": 123
+            },
+            {
+              "label": "investigate",
+              "score": 1.0,
+              "start": 123,
+              "end": 124
+            },
+            {
+              "label": "and",
+              "score": 1.0,
+              "start": 124,
+              "end": 125
+            },
+            {
+              "label": "support",
+              "score": 1.0,
+              "start": 125,
+              "end": 126
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 126,
+              "end": 127
+            },
+            {
+              "label": "impeachment",
+              "score": 1.0,
+              "start": 127,
+              "end": 128
+            },
+            {
+              "label": "of",
+              "score": 1.0,
+              "start": 128,
+              "end": 129
+            },
+            {
+              "label": "nixon",
+              "score": 1.0,
+              "start": 129,
+              "end": 130
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 130,
+              "end": 131
+            },
+            {
+              "label": "because",
+              "score": 1.0,
+              "start": 131,
+              "end": 132
+            },
+            {
+              "label": "they",
+              "score": 1.0,
+              "start": 132,
+              "end": 133
+            },
+            {
+              "label": "be",
+              "score": 1.0,
+              "start": 133,
+              "end": 134
+            },
+            {
+              "label": "willing",
+              "score": 1.0,
+              "start": 134,
+              "end": 135
+            },
+            {
+              "label": "to",
+              "score": 1.0,
+              "start": 135,
+              "end": 136
+            },
+            {
+              "label": "see",
+              "score": 1.0,
+              "start": 136,
+              "end": 137
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 137,
+              "end": 138
+            },
+            {
+              "label": "truth",
+              "score": 1.0,
+              "start": 138,
+              "end": 139
+            },
+            {
+              "label": "serve",
+              "score": 1.0,
+              "start": 139,
+              "end": 140
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 140,
+              "end": 141
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 141,
+              "end": 142
+            },
+            {
+              "label": "nixon",
+              "score": 1.0,
+              "start": 142,
+              "end": 143
+            },
+            {
+              "label": "resign",
+              "score": 1.0,
+              "start": 143,
+              "end": 144
+            },
+            {
+              "label": "before",
+              "score": 1.0,
+              "start": 144,
+              "end": 145
+            },
+            {
+              "label": "a",
+              "score": 1.0,
+              "start": 145,
+              "end": 146
+            },
+            {
+              "label": "trial",
+              "score": 1.0,
+              "start": 146,
+              "end": 147
+            },
+            {
+              "label": "in",
+              "score": 1.0,
+              "start": 147,
+              "end": 148
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 148,
+              "end": 149
+            },
+            {
+              "label": "u",
+              "score": 1.0,
+              "start": 149,
+              "end": 150
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 150,
+              "end": 151
+            },
+            {
+              "label": "s.",
+              "score": 1.0,
+              "start": 151,
+              "end": 152
+            },
+            {
+              "label": "senate",
+              "score": 1.0,
+              "start": 152,
+              "end": 153
+            },
+            {
+              "label": "could",
+              "score": 1.0,
+              "start": 153,
+              "end": 154
+            },
+            {
+              "label": "happen",
+              "score": 1.0,
+              "start": 154,
+              "end": 155
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 155,
+              "end": 156
+            },
+            {
+              "label": "bernstein",
+              "score": 1.0,
+              "start": 156,
+              "end": 157
+            },
+            {
+              "label": "say",
+              "score": 1.0,
+              "start": 157,
+              "end": 158
+            },
+            {
+              "label": "there",
+              "score": 1.0,
+              "start": 158,
+              "end": 159
+            },
+            {
+              "label": "have",
+              "score": 1.0,
+              "start": 159,
+              "end": 160
+            },
+            {
+              "label": "not",
+              "score": 1.0,
+              "start": 160,
+              "end": 161
+            },
+            {
+              "label": "be",
+              "score": 1.0,
+              "start": 161,
+              "end": 162
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 162,
+              "end": 163
+            },
+            {
+              "label": "something",
+              "score": 1.0,
+              "start": 163,
+              "end": 164
+            },
+            {
+              "label": "similar",
+              "score": 1.0,
+              "start": 164,
+              "end": 165
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 165,
+              "end": 166
+            },
+            {
+              "label": "yet",
+              "score": 1.0,
+              "start": 166,
+              "end": 167
+            },
+            {
+              "label": "from",
+              "score": 1.0,
+              "start": 167,
+              "end": 168
+            },
+            {
+              "label": "republicans",
+              "score": 1.0,
+              "start": 168,
+              "end": 169
+            },
+            {
+              "label": "today",
+              "score": 1.0,
+              "start": 169,
+              "end": 170
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 170,
+              "end": 171
+            },
+            {
+              "label": "he",
+              "score": 1.0,
+              "start": 171,
+              "end": 172
+            },
+            {
+              "label": "say",
+              "score": 1.0,
+              "start": 172,
+              "end": 173
+            },
+            {
+              "label": "while",
+              "score": 1.0,
+              "start": 173,
+              "end": 174
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 174,
+              "end": 175
+            },
+            {
+              "label": "numerous",
+              "score": 1.0,
+              "start": 175,
+              "end": 176
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 176,
+              "end": 177
+            },
+            {
+              "label": "member",
+              "score": 1.0,
+              "start": 177,
+              "end": 178
+            },
+            {
+              "label": "of",
+              "score": 1.0,
+              "start": 178,
+              "end": 179
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 179,
+              "end": 180
+            },
+            {
+              "label": "party",
+              "score": 1.0,
+              "start": 180,
+              "end": 181
+            },
+            {
+              "label": "have",
+              "score": 1.0,
+              "start": 181,
+              "end": 182
+            },
+            {
+              "label": "be",
+              "score": 1.0,
+              "start": 182,
+              "end": 183
+            },
+            {
+              "label": "quietly",
+              "score": 1.0,
+              "start": 183,
+              "end": 184
+            },
+            {
+              "label": "critical",
+              "score": 1.0,
+              "start": 184,
+              "end": 185
+            },
+            {
+              "label": "of",
+              "score": 1.0,
+              "start": 185,
+              "end": 186
+            },
+            {
+              "label": "trump",
+              "score": 1.0,
+              "start": 186,
+              "end": 187
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 187,
+              "end": 188
+            },
+            {
+              "label": "conservative",
+              "score": 1.0,
+              "start": 188,
+              "end": 189
+            },
+            {
+              "label": "leadership",
+              "score": 1.0,
+              "start": 189,
+              "end": 190
+            },
+            {
+              "label": "have",
+              "score": 1.0,
+              "start": 190,
+              "end": 191
+            },
+            {
+              "label": "be",
+              "score": 1.0,
+              "start": 191,
+              "end": 192
+            },
+            {
+              "label": "either",
+              "score": 1.0,
+              "start": 192,
+              "end": 193
+            },
+            {
+              "label": "silent",
+              "score": 1.0,
+              "start": 193,
+              "end": 194
+            },
+            {
+              "label": "or",
+              "score": 1.0,
+              "start": 194,
+              "end": 195
+            },
+            {
+              "label": "supportive",
+              "score": 1.0,
+              "start": 195,
+              "end": 196
+            },
+            {
+              "label": "of",
+              "score": 1.0,
+              "start": 196,
+              "end": 197
+            },
+            {
+              "label": "him",
+              "score": 1.0,
+              "start": 197,
+              "end": 198
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 198,
+              "end": 199
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "viewName": "NER_CONLL",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.SpanLabelView",
+          "viewName": "NER_CONLL",
+          "generator": "NER_CONLL-annotator",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "PER",
+              "score": 1.0,
+              "start": 0,
+              "end": 1
+            },
+            {
+              "label": "ORG",
+              "score": 1.0,
+              "start": 3,
+              "end": 4
+            },
+            {
+              "label": "ORG",
+              "score": 1.0,
+              "start": 9,
+              "end": 11
+            },
+            {
+              "label": "PER",
+              "score": 1.0,
+              "start": 13,
+              "end": 14
+            },
+            {
+              "label": "ORG",
+              "score": 1.0,
+              "start": 21,
+              "end": 22
+            },
+            {
+              "label": "MISC",
+              "score": 1.0,
+              "start": 31,
+              "end": 32
+            },
+            {
+              "label": "LOC",
+              "score": 1.0,
+              "start": 33,
+              "end": 34
+            },
+            {
+              "label": "PER",
+              "score": 1.0,
+              "start": 41,
+              "end": 42
+            },
+            {
+              "label": "ORG",
+              "score": 1.0,
+              "start": 46,
+              "end": 47
+            },
+            {
+              "label": "PER",
+              "score": 1.0,
+              "start": 48,
+              "end": 50
+            },
+            {
+              "label": "PER",
+              "score": 1.0,
+              "start": 53,
+              "end": 54
+            },
+            {
+              "label": "MISC",
+              "score": 1.0,
+              "start": 62,
+              "end": 63
+            },
+            {
+              "label": "LOC",
+              "score": 1.0,
+              "start": 65,
+              "end": 66
+            },
+            {
+              "label": "PER",
+              "score": 1.0,
+              "start": 69,
+              "end": 70
+            },
+            {
+              "label": "MISC",
+              "score": 1.0,
+              "start": 86,
+              "end": 87
+            },
+            {
+              "label": "MISC",
+              "score": 1.0,
+              "start": 88,
+              "end": 89
+            },
+            {
+              "label": "PER",
+              "score": 1.0,
+              "start": 115,
+              "end": 116
+            },
+            {
+              "label": "MISC",
+              "score": 1.0,
+              "start": 122,
+              "end": 123
+            },
+            {
+              "label": "PER",
+              "score": 1.0,
+              "start": 129,
+              "end": 130
+            },
+            {
+              "label": "PER",
+              "score": 1.0,
+              "start": 142,
+              "end": 143
+            },
+            {
+              "label": "PER",
+              "score": 1.0,
+              "start": 151,
+              "end": 153
+            },
+            {
+              "label": "PER",
+              "score": 1.0,
+              "start": 156,
+              "end": 157
+            },
+            {
+              "label": "MISC",
+              "score": 1.0,
+              "start": 168,
+              "end": 169
+            },
+            {
+              "label": "PER",
+              "score": 1.0,
+              "start": 186,
+              "end": 187
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "viewName": "NER_ONTONOTES",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.SpanLabelView",
+          "viewName": "NER_ONTONOTES",
+          "generator": "NER_ONTONOTES-annotator",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "PERSON",
+              "score": 1.0,
+              "start": 0,
+              "end": 1
+            },
+            {
+              "label": "ORG",
+              "score": 1.0,
+              "start": 3,
+              "end": 4
+            },
+            {
+              "label": "ORG",
+              "score": 1.0,
+              "start": 8,
+              "end": 11
+            },
+            {
+              "label": "PERSON",
+              "score": 1.0,
+              "start": 13,
+              "end": 14
+            },
+            {
+              "label": "DATE",
+              "score": 1.0,
+              "start": 15,
+              "end": 17
+            },
+            {
+              "label": "DATE",
+              "score": 1.0,
+              "start": 19,
+              "end": 20
+            },
+            {
+              "label": "ORG",
+              "score": 1.0,
+              "start": 21,
+              "end": 22
+            },
+            {
+              "label": "WORK_OF_ART",
+              "score": 1.0,
+              "start": 23,
+              "end": 27
+            },
+            {
+              "label": "NORP",
+              "score": 1.0,
+              "start": 31,
+              "end": 32
+            },
+            {
+              "label": "ORG",
+              "score": 1.0,
+              "start": 33,
+              "end": 34
+            },
+            {
+              "label": "PERSON",
+              "score": 1.0,
+              "start": 41,
+              "end": 42
+            },
+            {
+              "label": "ORG",
+              "score": 1.0,
+              "start": 46,
+              "end": 47
+            },
+            {
+              "label": "PERSON",
+              "score": 1.0,
+              "start": 48,
+              "end": 50
+            },
+            {
+              "label": "DATE",
+              "score": 1.0,
+              "start": 50,
+              "end": 52
+            },
+            {
+              "label": "PERSON",
+              "score": 1.0,
+              "start": 53,
+              "end": 54
+            },
+            {
+              "label": "PERSON",
+              "score": 1.0,
+              "start": 62,
+              "end": 63
+            },
+            {
+              "label": "GPE",
+              "score": 1.0,
+              "start": 65,
+              "end": 66
+            },
+            {
+              "label": "PERSON",
+              "score": 1.0,
+              "start": 69,
+              "end": 70
+            },
+            {
+              "label": "NORP",
+              "score": 1.0,
+              "start": 86,
+              "end": 87
+            },
+            {
+              "label": "EVENT",
+              "score": 1.0,
+              "start": 88,
+              "end": 89
+            },
+            {
+              "label": "PERSON",
+              "score": 1.0,
+              "start": 115,
+              "end": 116
+            },
+            {
+              "label": "NORP",
+              "score": 1.0,
+              "start": 122,
+              "end": 123
+            },
+            {
+              "label": "PERSON",
+              "score": 1.0,
+              "start": 129,
+              "end": 130
+            },
+            {
+              "label": "PERSON",
+              "score": 1.0,
+              "start": 142,
+              "end": 143
+            },
+            {
+              "label": "ORG",
+              "score": 1.0,
+              "start": 152,
+              "end": 153
+            },
+            {
+              "label": "PERSON",
+              "score": 1.0,
+              "start": 156,
+              "end": 157
+            },
+            {
+              "label": "NORP",
+              "score": 1.0,
+              "start": 168,
+              "end": 169
+            },
+            {
+              "label": "DATE",
+              "score": 1.0,
+              "start": 169,
+              "end": 170
+            },
+            {
+              "label": "PERSON",
+              "score": 1.0,
+              "start": 186,
+              "end": 187
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "viewName": "PARSE_STANFORD",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.TreeView",
+          "viewName": "PARSE_STANFORD",
+          "generator": "StanfordParseHandler",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "ROOT",
+              "score": 1.0,
+              "start": 0,
+              "end": 53
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 0,
+              "end": 53
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 0,
+              "end": 18
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 0,
+              "end": 1
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 0,
+              "end": 1
+            },
+            {
+              "label": "Bernstein",
+              "score": 1.0,
+              "start": 0,
+              "end": 1
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 1,
+              "end": 2
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 1,
+              "end": 2
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 2,
+              "end": 17
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 2,
+              "end": 5
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 2,
+              "end": 3
+            },
+            {
+              "label": "a",
+              "score": 1.0,
+              "start": 2,
+              "end": 3
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 3,
+              "end": 4
+            },
+            {
+              "label": "CNN",
+              "score": 1.0,
+              "start": 3,
+              "end": 4
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 4,
+              "end": 5
+            },
+            {
+              "label": "contributor",
+              "score": 1.0,
+              "start": 4,
+              "end": 5
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 5,
+              "end": 17
+            },
+            {
+              "label": "WHNP",
+              "score": 1.0,
+              "start": 5,
+              "end": 11
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 5,
+              "end": 7
+            },
+            {
+              "label": "WP$",
+              "score": 1.0,
+              "start": 5,
+              "end": 6
+            },
+            {
+              "label": "whose",
+              "score": 1.0,
+              "start": 5,
+              "end": 6
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 6,
+              "end": 7
+            },
+            {
+              "label": "reporting",
+              "score": 1.0,
+              "start": 6,
+              "end": 7
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 7,
+              "end": 11
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 7,
+              "end": 8
+            },
+            {
+              "label": "for",
+              "score": 1.0,
+              "start": 7,
+              "end": 8
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 8,
+              "end": 11
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 8,
+              "end": 9
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 8,
+              "end": 9
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 9,
+              "end": 10
+            },
+            {
+              "label": "Washington",
+              "score": 1.0,
+              "start": 9,
+              "end": 10
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 10,
+              "end": 11
+            },
+            {
+              "label": "Post",
+              "score": 1.0,
+              "start": 10,
+              "end": 11
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 11,
+              "end": 17
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 11,
+              "end": 17
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 11,
+              "end": 12
+            },
+            {
+              "label": "helped",
+              "score": 1.0,
+              "start": 11,
+              "end": 12
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 12,
+              "end": 17
+            },
+            {
+              "label": "VB",
+              "score": 1.0,
+              "start": 12,
+              "end": 13
+            },
+            {
+              "label": "topple",
+              "score": 1.0,
+              "start": 12,
+              "end": 13
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 13,
+              "end": 17
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 13,
+              "end": 14
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 13,
+              "end": 14
+            },
+            {
+              "label": "Nixon",
+              "score": 1.0,
+              "start": 13,
+              "end": 14
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 14,
+              "end": 17
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 14,
+              "end": 15
+            },
+            {
+              "label": "in",
+              "score": 1.0,
+              "start": 14,
+              "end": 15
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 15,
+              "end": 17
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 15,
+              "end": 16
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 15,
+              "end": 16
+            },
+            {
+              "label": "NNS",
+              "score": 1.0,
+              "start": 16,
+              "end": 17
+            },
+            {
+              "label": "1970s",
+              "score": 1.0,
+              "start": 16,
+              "end": 17
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 17,
+              "end": 18
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 17,
+              "end": 18
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 18,
+              "end": 52
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 18,
+              "end": 19
+            },
+            {
+              "label": "said",
+              "score": 1.0,
+              "start": 18,
+              "end": 19
+            },
+            {
+              "label": "NP-TMP",
+              "score": 1.0,
+              "start": 19,
+              "end": 20
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 19,
+              "end": 20
+            },
+            {
+              "label": "Sunday",
+              "score": 1.0,
+              "start": 19,
+              "end": 20
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 20,
+              "end": 52
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 20,
+              "end": 21
+            },
+            {
+              "label": "on",
+              "score": 1.0,
+              "start": 20,
+              "end": 21
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 21,
+              "end": 25
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 21,
+              "end": 23
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 21,
+              "end": 22
+            },
+            {
+              "label": "CNN",
+              "score": 1.0,
+              "start": 21,
+              "end": 22
+            },
+            {
+              "label": "POS",
+              "score": 1.0,
+              "start": 22,
+              "end": 23
+            },
+            {
+              "label": "\u0027s",
+              "score": 1.0,
+              "start": 22,
+              "end": 23
+            },
+            {
+              "label": "``",
+              "score": 1.0,
+              "start": 23,
+              "end": 24
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 23,
+              "end": 24
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 24,
+              "end": 25
+            },
+            {
+              "label": "Reliable",
+              "score": 1.0,
+              "start": 24,
+              "end": 25
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 25,
+              "end": 52
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 25,
+              "end": 26
+            },
+            {
+              "label": "NNS",
+              "score": 1.0,
+              "start": 25,
+              "end": 26
+            },
+            {
+              "label": "Sources",
+              "score": 1.0,
+              "start": 25,
+              "end": 26
+            },
+            {
+              "label": "``",
+              "score": 1.0,
+              "start": 26,
+              "end": 27
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 26,
+              "end": 27
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 27,
+              "end": 52
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 27,
+              "end": 28
+            },
+            {
+              "label": "that",
+              "score": 1.0,
+              "start": 27,
+              "end": 28
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 28,
+              "end": 52
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 28,
+              "end": 29
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 28,
+              "end": 29
+            },
+            {
+              "label": "he",
+              "score": 1.0,
+              "start": 28,
+              "end": 29
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 29,
+              "end": 52
+            },
+            {
+              "label": "VBZ",
+              "score": 1.0,
+              "start": 29,
+              "end": 30
+            },
+            {
+              "label": "is",
+              "score": 1.0,
+              "start": 29,
+              "end": 30
+            },
+            {
+              "label": "ADJP",
+              "score": 1.0,
+              "start": 30,
+              "end": 50
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 30,
+              "end": 31
+            },
+            {
+              "label": "concerned",
+              "score": 1.0,
+              "start": 30,
+              "end": 31
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 31,
+              "end": 50
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 31,
+              "end": 50
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 31,
+              "end": 34
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 31,
+              "end": 32
+            },
+            {
+              "label": "NNS",
+              "score": 1.0,
+              "start": 31,
+              "end": 32
+            },
+            {
+              "label": "Republicans",
+              "score": 1.0,
+              "start": 31,
+              "end": 32
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 32,
+              "end": 34
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 32,
+              "end": 33
+            },
+            {
+              "label": "in",
+              "score": 1.0,
+              "start": 32,
+              "end": 33
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 33,
+              "end": 34
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 33,
+              "end": 34
+            },
+            {
+              "label": "Congress",
+              "score": 1.0,
+              "start": 33,
+              "end": 34
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 34,
+              "end": 50
+            },
+            {
+              "label": "VBP",
+              "score": 1.0,
+              "start": 34,
+              "end": 35
+            },
+            {
+              "label": "have",
+              "score": 1.0,
+              "start": 34,
+              "end": 35
+            },
+            {
+              "label": "RB",
+              "score": 1.0,
+              "start": 35,
+              "end": 36
+            },
+            {
+              "label": "n\u0027t",
+              "score": 1.0,
+              "start": 35,
+              "end": 36
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 36,
+              "end": 50
+            },
+            {
+              "label": "VBN",
+              "score": 1.0,
+              "start": 36,
+              "end": 37
+            },
+            {
+              "label": "voiced",
+              "score": 1.0,
+              "start": 36,
+              "end": 37
+            },
+            {
+              "label": "ADVP",
+              "score": 1.0,
+              "start": 37,
+              "end": 38
+            },
+            {
+              "label": "RBR",
+              "score": 1.0,
+              "start": 37,
+              "end": 38
+            },
+            {
+              "label": "more",
+              "score": 1.0,
+              "start": 37,
+              "end": 38
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 38,
+              "end": 44
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 38,
+              "end": 39
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 38,
+              "end": 39
+            },
+            {
+              "label": "skepticism",
+              "score": 1.0,
+              "start": 38,
+              "end": 39
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 39,
+              "end": 44
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 39,
+              "end": 40
+            },
+            {
+              "label": "of",
+              "score": 1.0,
+              "start": 39,
+              "end": 40
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 40,
+              "end": 44
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 40,
+              "end": 43
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 40,
+              "end": 41
+            },
+            {
+              "label": "President",
+              "score": 1.0,
+              "start": 40,
+              "end": 41
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 41,
+              "end": 42
+            },
+            {
+              "label": "Trump",
+              "score": 1.0,
+              "start": 41,
+              "end": 42
+            },
+            {
+              "label": "POS",
+              "score": 1.0,
+              "start": 42,
+              "end": 43
+            },
+            {
+              "label": "\u0027s",
+              "score": 1.0,
+              "start": 42,
+              "end": 43
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 43,
+              "end": 44
+            },
+            {
+              "label": "decision",
+              "score": 1.0,
+              "start": 43,
+              "end": 44
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 44,
+              "end": 50
+            },
+            {
+              "label": "TO",
+              "score": 1.0,
+              "start": 44,
+              "end": 45
+            },
+            {
+              "label": "to",
+              "score": 1.0,
+              "start": 44,
+              "end": 45
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 45,
+              "end": 50
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 45,
+              "end": 46
+            },
+            {
+              "label": "fire",
+              "score": 1.0,
+              "start": 45,
+              "end": 46
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 46,
+              "end": 47
+            },
+            {
+              "label": "FBI",
+              "score": 1.0,
+              "start": 46,
+              "end": 47
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 47,
+              "end": 48
+            },
+            {
+              "label": "Director",
+              "score": 1.0,
+              "start": 47,
+              "end": 48
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 48,
+              "end": 49
+            },
+            {
+              "label": "James",
+              "score": 1.0,
+              "start": 48,
+              "end": 49
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 49,
+              "end": 50
+            },
+            {
+              "label": "Comey",
+              "score": 1.0,
+              "start": 49,
+              "end": 50
+            },
+            {
+              "label": "NP-TMP",
+              "score": 1.0,
+              "start": 50,
+              "end": 52
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 50,
+              "end": 51
+            },
+            {
+              "label": "last",
+              "score": 1.0,
+              "start": 50,
+              "end": 51
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 51,
+              "end": 52
+            },
+            {
+              "label": "week",
+              "score": 1.0,
+              "start": 51,
+              "end": 52
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 52,
+              "end": 53
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 52,
+              "end": 53
+            },
+            {
+              "label": "ROOT",
+              "score": 1.0,
+              "start": 53,
+              "end": 67
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 53,
+              "end": 67
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 53,
+              "end": 56
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 53,
+              "end": 55
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 53,
+              "end": 54
+            },
+            {
+              "label": "Comey",
+              "score": 1.0,
+              "start": 53,
+              "end": 54
+            },
+            {
+              "label": "POS",
+              "score": 1.0,
+              "start": 54,
+              "end": 55
+            },
+            {
+              "label": "\u0027s",
+              "score": 1.0,
+              "start": 54,
+              "end": 55
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 55,
+              "end": 56
+            },
+            {
+              "label": "department",
+              "score": 1.0,
+              "start": 55,
+              "end": 56
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 56,
+              "end": 66
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 56,
+              "end": 57
+            },
+            {
+              "label": "was",
+              "score": 1.0,
+              "start": 56,
+              "end": 57
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 57,
+              "end": 66
+            },
+            {
+              "label": "VBG",
+              "score": 1.0,
+              "start": 57,
+              "end": 58
+            },
+            {
+              "label": "investigating",
+              "score": 1.0,
+              "start": 57,
+              "end": 58
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 58,
+              "end": 66
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 58,
+              "end": 60
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 58,
+              "end": 59
+            },
+            {
+              "label": "potential",
+              "score": 1.0,
+              "start": 58,
+              "end": 59
+            },
+            {
+              "label": "NNS",
+              "score": 1.0,
+              "start": 59,
+              "end": 60
+            },
+            {
+              "label": "ties",
+              "score": 1.0,
+              "start": 59,
+              "end": 60
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 60,
+              "end": 66
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 60,
+              "end": 61
+            },
+            {
+              "label": "between",
+              "score": 1.0,
+              "start": 60,
+              "end": 61
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 61,
+              "end": 66
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 61,
+              "end": 64
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 61,
+              "end": 62
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 61,
+              "end": 62
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 62,
+              "end": 63
+            },
+            {
+              "label": "Trump",
+              "score": 1.0,
+              "start": 62,
+              "end": 63
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 63,
+              "end": 64
+            },
+            {
+              "label": "campaign",
+              "score": 1.0,
+              "start": 63,
+              "end": 64
+            },
+            {
+              "label": "CC",
+              "score": 1.0,
+              "start": 64,
+              "end": 65
+            },
+            {
+              "label": "and",
+              "score": 1.0,
+              "start": 64,
+              "end": 65
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 65,
+              "end": 66
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 65,
+              "end": 66
+            },
+            {
+              "label": "Russia",
+              "score": 1.0,
+              "start": 65,
+              "end": 66
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 66,
+              "end": 67
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 66,
+              "end": 67
+            },
+            {
+              "label": "ROOT",
+              "score": 1.0,
+              "start": 67,
+              "end": 92
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 67,
+              "end": 92
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 67,
+              "end": 68
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 67,
+              "end": 68
+            },
+            {
+              "label": "VBN",
+              "score": 1.0,
+              "start": 67,
+              "end": 68
+            },
+            {
+              "label": "Related",
+              "score": 1.0,
+              "start": 67,
+              "end": 68
+            },
+            {
+              "label": ":",
+              "score": 1.0,
+              "start": 68,
+              "end": 69
+            },
+            {
+              "label": ":",
+              "score": 1.0,
+              "start": 68,
+              "end": 69
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 69,
+              "end": 91
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 69,
+              "end": 76
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 69,
+              "end": 72
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 69,
+              "end": 71
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 69,
+              "end": 70
+            },
+            {
+              "label": "Trump",
+              "score": 1.0,
+              "start": 69,
+              "end": 70
+            },
+            {
+              "label": "POS",
+              "score": 1.0,
+              "start": 70,
+              "end": 71
+            },
+            {
+              "label": "\u0027s",
+              "score": 1.0,
+              "start": 70,
+              "end": 71
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 71,
+              "end": 72
+            },
+            {
+              "label": "chief",
+              "score": 1.0,
+              "start": 71,
+              "end": 72
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 72,
+              "end": 74
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 72,
+              "end": 73
+            },
+            {
+              "label": "of",
+              "score": 1.0,
+              "start": 72,
+              "end": 73
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 73,
+              "end": 74
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 73,
+              "end": 74
+            },
+            {
+              "label": "staff",
+              "score": 1.0,
+              "start": 73,
+              "end": 74
+            },
+            {
+              "label": ":",
+              "score": 1.0,
+              "start": 74,
+              "end": 75
+            },
+            {
+              "label": ":",
+              "score": 1.0,
+              "start": 74,
+              "end": 75
+            },
+            {
+              "label": "\u0027\u0027",
+              "score": 1.0,
+              "start": 75,
+              "end": 76
+            },
+            {
+              "label": "\u0027",
+              "score": 1.0,
+              "start": 75,
+              "end": 76
+            },
+            {
+              "label": "ADVP",
+              "score": 1.0,
+              "start": 76,
+              "end": 77
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 76,
+              "end": 77
+            },
+            {
+              "label": "We",
+              "score": 1.0,
+              "start": 76,
+              "end": 77
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 77,
+              "end": 91
+            },
+            {
+              "label": "VBP",
+              "score": 1.0,
+              "start": 77,
+              "end": 78
+            },
+            {
+              "label": "\u0027ve",
+              "score": 1.0,
+              "start": 77,
+              "end": 78
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 78,
+              "end": 91
+            },
+            {
+              "label": "VBN",
+              "score": 1.0,
+              "start": 78,
+              "end": 79
+            },
+            {
+              "label": "looked",
+              "score": 1.0,
+              "start": 78,
+              "end": 79
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 79,
+              "end": 91
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 79,
+              "end": 80
+            },
+            {
+              "label": "at",
+              "score": 1.0,
+              "start": 79,
+              "end": 80
+            },
+            {
+              "label": "\u0027\u0027",
+              "score": 1.0,
+              "start": 80,
+              "end": 81
+            },
+            {
+              "label": "\u0027",
+              "score": 1.0,
+              "start": 80,
+              "end": 81
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 81,
+              "end": 91
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 81,
+              "end": 84
+            },
+            {
+              "label": "VBG",
+              "score": 1.0,
+              "start": 81,
+              "end": 82
+            },
+            {
+              "label": "changing",
+              "score": 1.0,
+              "start": 81,
+              "end": 82
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 82,
+              "end": 83
+            },
+            {
+              "label": "libel",
+              "score": 1.0,
+              "start": 82,
+              "end": 83
+            },
+            {
+              "label": "NNS",
+              "score": 1.0,
+              "start": 83,
+              "end": 84
+            },
+            {
+              "label": "laws",
+              "score": 1.0,
+              "start": 83,
+              "end": 84
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 84,
+              "end": 91
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 84,
+              "end": 91
+            },
+            {
+              "label": "``",
+              "score": 1.0,
+              "start": 84,
+              "end": 85
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 84,
+              "end": 85
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 85,
+              "end": 89
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 85,
+              "end": 87
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 85,
+              "end": 86
+            },
+            {
+              "label": "The",
+              "score": 1.0,
+              "start": 85,
+              "end": 86
+            },
+            {
+              "label": "NNPS",
+              "score": 1.0,
+              "start": 86,
+              "end": 87
+            },
+            {
+              "label": "Republicans",
+              "score": 1.0,
+              "start": 86,
+              "end": 87
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 87,
+              "end": 89
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 87,
+              "end": 88
+            },
+            {
+              "label": "during",
+              "score": 1.0,
+              "start": 87,
+              "end": 88
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 88,
+              "end": 89
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 88,
+              "end": 89
+            },
+            {
+              "label": "Watergate",
+              "score": 1.0,
+              "start": 88,
+              "end": 89
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 89,
+              "end": 91
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 89,
+              "end": 90
+            },
+            {
+              "label": "were",
+              "score": 1.0,
+              "start": 89,
+              "end": 90
+            },
+            {
+              "label": "ADJP",
+              "score": 1.0,
+              "start": 90,
+              "end": 91
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 90,
+              "end": 91
+            },
+            {
+              "label": "heroic",
+              "score": 1.0,
+              "start": 90,
+              "end": 91
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 91,
+              "end": 92
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 91,
+              "end": 92
+            },
+            {
+              "label": "ROOT",
+              "score": 1.0,
+              "start": 92,
+              "end": 118
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 92,
+              "end": 118
+            },
+            {
+              "label": "SBARQ",
+              "score": 1.0,
+              "start": 92,
+              "end": 114
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 92,
+              "end": 98
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 92,
+              "end": 93
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 92,
+              "end": 93
+            },
+            {
+              "label": "They",
+              "score": 1.0,
+              "start": 92,
+              "end": 93
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 93,
+              "end": 98
+            },
+            {
+              "label": "VBP",
+              "score": 1.0,
+              "start": 93,
+              "end": 94
+            },
+            {
+              "label": "are",
+              "score": 1.0,
+              "start": 93,
+              "end": 94
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 94,
+              "end": 98
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 94,
+              "end": 96
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 94,
+              "end": 95
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 94,
+              "end": 95
+            },
+            {
+              "label": "NNS",
+              "score": 1.0,
+              "start": 95,
+              "end": 96
+            },
+            {
+              "label": "ones",
+              "score": 1.0,
+              "start": 95,
+              "end": 96
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 96,
+              "end": 98
+            },
+            {
+              "label": "WHNP",
+              "score": 1.0,
+              "start": 96,
+              "end": 97
+            },
+            {
+              "label": "WP",
+              "score": 1.0,
+              "start": 96,
+              "end": 97
+            },
+            {
+              "label": "who",
+              "score": 1.0,
+              "start": 96,
+              "end": 97
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 97,
+              "end": 98
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 97,
+              "end": 98
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 97,
+              "end": 98
+            },
+            {
+              "label": "said",
+              "score": 1.0,
+              "start": 97,
+              "end": 98
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 98,
+              "end": 99
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 98,
+              "end": 99
+            },
+            {
+              "label": "\u0027\u0027",
+              "score": 1.0,
+              "start": 99,
+              "end": 100
+            },
+            {
+              "label": "\u0027",
+              "score": 1.0,
+              "start": 99,
+              "end": 100
+            },
+            {
+              "label": "WHNP",
+              "score": 1.0,
+              "start": 100,
+              "end": 101
+            },
+            {
+              "label": "WP",
+              "score": 1.0,
+              "start": 100,
+              "end": 101
+            },
+            {
+              "label": "What",
+              "score": 1.0,
+              "start": 100,
+              "end": 101
+            },
+            {
+              "label": "SQ",
+              "score": 1.0,
+              "start": 101,
+              "end": 112
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 101,
+              "end": 112
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 101,
+              "end": 102
+            },
+            {
+              "label": "did",
+              "score": 1.0,
+              "start": 101,
+              "end": 102
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 102,
+              "end": 112
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 102,
+              "end": 105
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 102,
+              "end": 105
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 102,
+              "end": 104
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 102,
+              "end": 103
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 102,
+              "end": 103
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 103,
+              "end": 104
+            },
+            {
+              "label": "president",
+              "score": 1.0,
+              "start": 103,
+              "end": 104
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 104,
+              "end": 105
+            },
+            {
+              "label": "VB",
+              "score": 1.0,
+              "start": 104,
+              "end": 105
+            },
+            {
+              "label": "know",
+              "score": 1.0,
+              "start": 104,
+              "end": 105
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 105,
+              "end": 106
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 105,
+              "end": 106
+            },
+            {
+              "label": "CC",
+              "score": 1.0,
+              "start": 106,
+              "end": 107
+            },
+            {
+              "label": "and",
+              "score": 1.0,
+              "start": 106,
+              "end": 107
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 107,
+              "end": 112
+            },
+            {
+              "label": "WHADVP",
+              "score": 1.0,
+              "start": 107,
+              "end": 108
+            },
+            {
+              "label": "WRB",
+              "score": 1.0,
+              "start": 107,
+              "end": 108
+            },
+            {
+              "label": "when",
+              "score": 1.0,
+              "start": 107,
+              "end": 108
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 108,
+              "end": 112
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 108,
+              "end": 112
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 108,
+              "end": 109
+            },
+            {
+              "label": "did",
+              "score": 1.0,
+              "start": 108,
+              "end": 109
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 109,
+              "end": 112
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 109,
+              "end": 110
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 109,
+              "end": 110
+            },
+            {
+              "label": "he",
+              "score": 1.0,
+              "start": 109,
+              "end": 110
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 110,
+              "end": 112
+            },
+            {
+              "label": "VB",
+              "score": 1.0,
+              "start": 110,
+              "end": 111
+            },
+            {
+              "label": "know",
+              "score": 1.0,
+              "start": 110,
+              "end": 111
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 111,
+              "end": 112
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 111,
+              "end": 112
+            },
+            {
+              "label": "it",
+              "score": 1.0,
+              "start": 111,
+              "end": 112
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 112,
+              "end": 113
+            },
+            {
+              "label": "?",
+              "score": 1.0,
+              "start": 112,
+              "end": 113
+            },
+            {
+              "label": "\u0027\u0027",
+              "score": 1.0,
+              "start": 113,
+              "end": 114
+            },
+            {
+              "label": "\u0027",
+              "score": 1.0,
+              "start": 113,
+              "end": 114
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 114,
+              "end": 116
+            },
+            {
+              "label": "``",
+              "score": 1.0,
+              "start": 114,
+              "end": 115
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 114,
+              "end": 115
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 115,
+              "end": 116
+            },
+            {
+              "label": "Bernstein",
+              "score": 1.0,
+              "start": 115,
+              "end": 116
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 116,
+              "end": 117
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 116,
+              "end": 117
+            },
+            {
+              "label": "said",
+              "score": 1.0,
+              "start": 116,
+              "end": 117
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 117,
+              "end": 118
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 117,
+              "end": 118
+            },
+            {
+              "label": "ROOT",
+              "score": 1.0,
+              "start": 118,
+              "end": 142
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 118,
+              "end": 142
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 118,
+              "end": 119
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 118,
+              "end": 119
+            },
+            {
+              "label": "He",
+              "score": 1.0,
+              "start": 118,
+              "end": 119
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 119,
+              "end": 140
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 119,
+              "end": 120
+            },
+            {
+              "label": "added",
+              "score": 1.0,
+              "start": 119,
+              "end": 120
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 120,
+              "end": 140
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 120,
+              "end": 121
+            },
+            {
+              "label": "that",
+              "score": 1.0,
+              "start": 120,
+              "end": 121
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 121,
+              "end": 140
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 121,
+              "end": 123
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 121,
+              "end": 122
+            },
+            {
+              "label": "those",
+              "score": 1.0,
+              "start": 121,
+              "end": 122
+            },
+            {
+              "label": "NNPS",
+              "score": 1.0,
+              "start": 122,
+              "end": 123
+            },
+            {
+              "label": "Republicans",
+              "score": 1.0,
+              "start": 122,
+              "end": 123
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 123,
+              "end": 140
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 123,
+              "end": 124
+            },
+            {
+              "label": "investigated",
+              "score": 1.0,
+              "start": 123,
+              "end": 124
+            },
+            {
+              "label": "CC",
+              "score": 1.0,
+              "start": 124,
+              "end": 125
+            },
+            {
+              "label": "and",
+              "score": 1.0,
+              "start": 124,
+              "end": 125
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 125,
+              "end": 126
+            },
+            {
+              "label": "supported",
+              "score": 1.0,
+              "start": 125,
+              "end": 126
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 126,
+              "end": 140
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 126,
+              "end": 128
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 126,
+              "end": 127
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 126,
+              "end": 127
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 127,
+              "end": 128
+            },
+            {
+              "label": "impeachment",
+              "score": 1.0,
+              "start": 127,
+              "end": 128
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 128,
+              "end": 140
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 128,
+              "end": 129
+            },
+            {
+              "label": "of",
+              "score": 1.0,
+              "start": 128,
+              "end": 129
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 129,
+              "end": 140
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 129,
+              "end": 130
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 129,
+              "end": 130
+            },
+            {
+              "label": "Nixon",
+              "score": 1.0,
+              "start": 129,
+              "end": 130
+            },
+            {
+              "label": "``",
+              "score": 1.0,
+              "start": 130,
+              "end": 131
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 130,
+              "end": 131
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 131,
+              "end": 140
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 131,
+              "end": 132
+            },
+            {
+              "label": "because",
+              "score": 1.0,
+              "start": 131,
+              "end": 132
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 132,
+              "end": 140
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 132,
+              "end": 133
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 132,
+              "end": 133
+            },
+            {
+              "label": "they",
+              "score": 1.0,
+              "start": 132,
+              "end": 133
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 133,
+              "end": 140
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 133,
+              "end": 134
+            },
+            {
+              "label": "were",
+              "score": 1.0,
+              "start": 133,
+              "end": 134
+            },
+            {
+              "label": "ADJP",
+              "score": 1.0,
+              "start": 134,
+              "end": 140
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 134,
+              "end": 135
+            },
+            {
+              "label": "willing",
+              "score": 1.0,
+              "start": 134,
+              "end": 135
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 135,
+              "end": 140
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 135,
+              "end": 140
+            },
+            {
+              "label": "TO",
+              "score": 1.0,
+              "start": 135,
+              "end": 136
+            },
+            {
+              "label": "to",
+              "score": 1.0,
+              "start": 135,
+              "end": 136
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 136,
+              "end": 140
+            },
+            {
+              "label": "VB",
+              "score": 1.0,
+              "start": 136,
+              "end": 137
+            },
+            {
+              "label": "see",
+              "score": 1.0,
+              "start": 136,
+              "end": 137
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 137,
+              "end": 140
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 137,
+              "end": 140
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 137,
+              "end": 139
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 137,
+              "end": 138
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 137,
+              "end": 138
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 138,
+              "end": 139
+            },
+            {
+              "label": "truth",
+              "score": 1.0,
+              "start": 138,
+              "end": 139
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 139,
+              "end": 140
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 139,
+              "end": 140
+            },
+            {
+              "label": "served",
+              "score": 1.0,
+              "start": 139,
+              "end": 140
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 140,
+              "end": 141
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 140,
+              "end": 141
+            },
+            {
+              "label": "\u0027\u0027",
+              "score": 1.0,
+              "start": 141,
+              "end": 142
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 141,
+              "end": 142
+            },
+            {
+              "label": "ROOT",
+              "score": 1.0,
+              "start": 142,
+              "end": 156
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 142,
+              "end": 156
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 142,
+              "end": 143
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 142,
+              "end": 143
+            },
+            {
+              "label": "Nixon",
+              "score": 1.0,
+              "start": 142,
+              "end": 143
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 143,
+              "end": 155
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 143,
+              "end": 144
+            },
+            {
+              "label": "resigned",
+              "score": 1.0,
+              "start": 143,
+              "end": 144
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 144,
+              "end": 155
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 144,
+              "end": 145
+            },
+            {
+              "label": "before",
+              "score": 1.0,
+              "start": 144,
+              "end": 145
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 145,
+              "end": 155
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 145,
+              "end": 153
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 145,
+              "end": 147
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 145,
+              "end": 146
+            },
+            {
+              "label": "a",
+              "score": 1.0,
+              "start": 145,
+              "end": 146
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 146,
+              "end": 147
+            },
+            {
+              "label": "trial",
+              "score": 1.0,
+              "start": 146,
+              "end": 147
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 147,
+              "end": 153
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 147,
+              "end": 148
+            },
+            {
+              "label": "in",
+              "score": 1.0,
+              "start": 147,
+              "end": 148
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 148,
+              "end": 153
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 148,
+              "end": 149
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 148,
+              "end": 149
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 149,
+              "end": 150
+            },
+            {
+              "label": "U",
+              "score": 1.0,
+              "start": 149,
+              "end": 150
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 150,
+              "end": 151
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 150,
+              "end": 151
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 151,
+              "end": 152
+            },
+            {
+              "label": "S.",
+              "score": 1.0,
+              "start": 151,
+              "end": 152
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 152,
+              "end": 153
+            },
+            {
+              "label": "Senate",
+              "score": 1.0,
+              "start": 152,
+              "end": 153
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 153,
+              "end": 155
+            },
+            {
+              "label": "MD",
+              "score": 1.0,
+              "start": 153,
+              "end": 154
+            },
+            {
+              "label": "could",
+              "score": 1.0,
+              "start": 153,
+              "end": 154
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 154,
+              "end": 155
+            },
+            {
+              "label": "VB",
+              "score": 1.0,
+              "start": 154,
+              "end": 155
+            },
+            {
+              "label": "happen",
+              "score": 1.0,
+              "start": 154,
+              "end": 155
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 155,
+              "end": 156
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 155,
+              "end": 156
+            },
+            {
+              "label": "ROOT",
+              "score": 1.0,
+              "start": 156,
+              "end": 171
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 156,
+              "end": 171
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 156,
+              "end": 157
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 156,
+              "end": 157
+            },
+            {
+              "label": "Bernstein",
+              "score": 1.0,
+              "start": 156,
+              "end": 157
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 157,
+              "end": 170
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 157,
+              "end": 158
+            },
+            {
+              "label": "said",
+              "score": 1.0,
+              "start": 157,
+              "end": 158
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 158,
+              "end": 170
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 158,
+              "end": 170
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 158,
+              "end": 159
+            },
+            {
+              "label": "EX",
+              "score": 1.0,
+              "start": 158,
+              "end": 159
+            },
+            {
+              "label": "there",
+              "score": 1.0,
+              "start": 158,
+              "end": 159
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 159,
+              "end": 170
+            },
+            {
+              "label": "VBZ",
+              "score": 1.0,
+              "start": 159,
+              "end": 160
+            },
+            {
+              "label": "has",
+              "score": 1.0,
+              "start": 159,
+              "end": 160
+            },
+            {
+              "label": "RB",
+              "score": 1.0,
+              "start": 160,
+              "end": 161
+            },
+            {
+              "label": "not",
+              "score": 1.0,
+              "start": 160,
+              "end": 161
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 161,
+              "end": 170
+            },
+            {
+              "label": "VBN",
+              "score": 1.0,
+              "start": 161,
+              "end": 162
+            },
+            {
+              "label": "been",
+              "score": 1.0,
+              "start": 161,
+              "end": 162
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 162,
+              "end": 169
+            },
+            {
+              "label": "``",
+              "score": 1.0,
+              "start": 162,
+              "end": 163
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 162,
+              "end": 163
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 163,
+              "end": 165
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 163,
+              "end": 164
+            },
+            {
+              "label": "something",
+              "score": 1.0,
+              "start": 163,
+              "end": 164
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 164,
+              "end": 165
+            },
+            {
+              "label": "similar",
+              "score": 1.0,
+              "start": 164,
+              "end": 165
+            },
+            {
+              "label": "``",
+              "score": 1.0,
+              "start": 165,
+              "end": 166
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 165,
+              "end": 166
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 166,
+              "end": 169
+            },
+            {
+              "label": "ADVP",
+              "score": 1.0,
+              "start": 166,
+              "end": 167
+            },
+            {
+              "label": "RB",
+              "score": 1.0,
+              "start": 166,
+              "end": 167
+            },
+            {
+              "label": "yet",
+              "score": 1.0,
+              "start": 166,
+              "end": 167
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 167,
+              "end": 168
+            },
+            {
+              "label": "from",
+              "score": 1.0,
+              "start": 167,
+              "end": 168
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 168,
+              "end": 169
+            },
+            {
+              "label": "NNPS",
+              "score": 1.0,
+              "start": 168,
+              "end": 169
+            },
+            {
+              "label": "Republicans",
+              "score": 1.0,
+              "start": 168,
+              "end": 169
+            },
+            {
+              "label": "NP-TMP",
+              "score": 1.0,
+              "start": 169,
+              "end": 170
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 169,
+              "end": 170
+            },
+            {
+              "label": "today",
+              "score": 1.0,
+              "start": 169,
+              "end": 170
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 170,
+              "end": 171
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 170,
+              "end": 171
+            },
+            {
+              "label": "ROOT",
+              "score": 1.0,
+              "start": 171,
+              "end": 199
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 171,
+              "end": 199
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 171,
+              "end": 187
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 171,
+              "end": 172
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 171,
+              "end": 172
+            },
+            {
+              "label": "He",
+              "score": 1.0,
+              "start": 171,
+              "end": 172
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 172,
+              "end": 187
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 172,
+              "end": 173
+            },
+            {
+              "label": "said",
+              "score": 1.0,
+              "start": 172,
+              "end": 173
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 173,
+              "end": 187
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 173,
+              "end": 174
+            },
+            {
+              "label": "while",
+              "score": 1.0,
+              "start": 173,
+              "end": 174
+            },
+            {
+              "label": "S",
+              "score": 1.0,
+              "start": 174,
+              "end": 187
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 174,
+              "end": 181
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 174,
+              "end": 178
+            },
+            {
+              "label": "``",
+              "score": 1.0,
+              "start": 174,
+              "end": 175
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 174,
+              "end": 175
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 175,
+              "end": 176
+            },
+            {
+              "label": "numerous",
+              "score": 1.0,
+              "start": 175,
+              "end": 176
+            },
+            {
+              "label": "\u0027\u0027",
+              "score": 1.0,
+              "start": 176,
+              "end": 177
+            },
+            {
+              "label": "\"",
+              "score": 1.0,
+              "start": 176,
+              "end": 177
+            },
+            {
+              "label": "NNS",
+              "score": 1.0,
+              "start": 177,
+              "end": 178
+            },
+            {
+              "label": "members",
+              "score": 1.0,
+              "start": 177,
+              "end": 178
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 178,
+              "end": 181
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 178,
+              "end": 179
+            },
+            {
+              "label": "of",
+              "score": 1.0,
+              "start": 178,
+              "end": 179
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 179,
+              "end": 181
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 179,
+              "end": 180
+            },
+            {
+              "label": "the",
+              "score": 1.0,
+              "start": 179,
+              "end": 180
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 180,
+              "end": 181
+            },
+            {
+              "label": "party",
+              "score": 1.0,
+              "start": 180,
+              "end": 181
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 181,
+              "end": 187
+            },
+            {
+              "label": "VBP",
+              "score": 1.0,
+              "start": 181,
+              "end": 182
+            },
+            {
+              "label": "have",
+              "score": 1.0,
+              "start": 181,
+              "end": 182
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 182,
+              "end": 187
+            },
+            {
+              "label": "VBN",
+              "score": 1.0,
+              "start": 182,
+              "end": 183
+            },
+            {
+              "label": "been",
+              "score": 1.0,
+              "start": 182,
+              "end": 183
+            },
+            {
+              "label": "ADVP",
+              "score": 1.0,
+              "start": 183,
+              "end": 184
+            },
+            {
+              "label": "RB",
+              "score": 1.0,
+              "start": 183,
+              "end": 184
+            },
+            {
+              "label": "quietly",
+              "score": 1.0,
+              "start": 183,
+              "end": 184
+            },
+            {
+              "label": "ADJP",
+              "score": 1.0,
+              "start": 184,
+              "end": 187
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 184,
+              "end": 185
+            },
+            {
+              "label": "critical",
+              "score": 1.0,
+              "start": 184,
+              "end": 185
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 185,
+              "end": 187
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 185,
+              "end": 186
+            },
+            {
+              "label": "of",
+              "score": 1.0,
+              "start": 185,
+              "end": 186
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 186,
+              "end": 187
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 186,
+              "end": 187
+            },
+            {
+              "label": "Trump",
+              "score": 1.0,
+              "start": 186,
+              "end": 187
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 187,
+              "end": 188
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 187,
+              "end": 188
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 188,
+              "end": 190
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 188,
+              "end": 189
+            },
+            {
+              "label": "conservative",
+              "score": 1.0,
+              "start": 188,
+              "end": 189
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 189,
+              "end": 190
+            },
+            {
+              "label": "leadership",
+              "score": 1.0,
+              "start": 189,
+              "end": 190
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 190,
+              "end": 198
+            },
+            {
+              "label": "VBZ",
+              "score": 1.0,
+              "start": 190,
+              "end": 191
+            },
+            {
+              "label": "has",
+              "score": 1.0,
+              "start": 190,
+              "end": 191
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 191,
+              "end": 198
+            },
+            {
+              "label": "VBN",
+              "score": 1.0,
+              "start": 191,
+              "end": 192
+            },
+            {
+              "label": "been",
+              "score": 1.0,
+              "start": 191,
+              "end": 192
+            },
+            {
+              "label": "ADJP",
+              "score": 1.0,
+              "start": 192,
+              "end": 196
+            },
+            {
+              "label": "RB",
+              "score": 1.0,
+              "start": 192,
+              "end": 193
+            },
+            {
+              "label": "either",
+              "score": 1.0,
+              "start": 192,
+              "end": 193
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 193,
+              "end": 194
+            },
+            {
+              "label": "silent",
+              "score": 1.0,
+              "start": 193,
+              "end": 194
+            },
+            {
+              "label": "CC",
+              "score": 1.0,
+              "start": 194,
+              "end": 195
+            },
+            {
+              "label": "or",
+              "score": 1.0,
+              "start": 194,
+              "end": 195
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 195,
+              "end": 196
+            },
+            {
+              "label": "supportive",
+              "score": 1.0,
+              "start": 195,
+              "end": 196
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 196,
+              "end": 198
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 196,
+              "end": 197
+            },
+            {
+              "label": "of",
+              "score": 1.0,
+              "start": 196,
+              "end": 197
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 197,
+              "end": 198
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 197,
+              "end": 198
+            },
+            {
+              "label": "him",
+              "score": 1.0,
+              "start": 197,
+              "end": 198
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 198,
+              "end": 199
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 198,
+              "end": 199
+            }
+          ],
+          "relations": [
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 0,
+              "targetConstituent": 1
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 1,
+              "targetConstituent": 2
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 2,
+              "targetConstituent": 3
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 3,
+              "targetConstituent": 4
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 4,
+              "targetConstituent": 5
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 2,
+              "targetConstituent": 6
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 6,
+              "targetConstituent": 7
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 2,
+              "targetConstituent": 8
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 8,
+              "targetConstituent": 9
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 9,
+              "targetConstituent": 10
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 10,
+              "targetConstituent": 11
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 9,
+              "targetConstituent": 12
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 12,
+              "targetConstituent": 13
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 9,
+              "targetConstituent": 14
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 14,
+              "targetConstituent": 15
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 8,
+              "targetConstituent": 16
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 16,
+              "targetConstituent": 17
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 17,
+              "targetConstituent": 18
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 18,
+              "targetConstituent": 19
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 19,
+              "targetConstituent": 20
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 18,
+              "targetConstituent": 21
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 21,
+              "targetConstituent": 22
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 17,
+              "targetConstituent": 23
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 23,
+              "targetConstituent": 24
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 24,
+              "targetConstituent": 25
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 23,
+              "targetConstituent": 26
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 26,
+              "targetConstituent": 27
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 27,
+              "targetConstituent": 28
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 26,
+              "targetConstituent": 29
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 29,
+              "targetConstituent": 30
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 26,
+              "targetConstituent": 31
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 31,
+              "targetConstituent": 32
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 16,
+              "targetConstituent": 33
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 33,
+              "targetConstituent": 34
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 34,
+              "targetConstituent": 35
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 35,
+              "targetConstituent": 36
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 34,
+              "targetConstituent": 37
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 37,
+              "targetConstituent": 38
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 38,
+              "targetConstituent": 39
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 37,
+              "targetConstituent": 40
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 40,
+              "targetConstituent": 41
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 41,
+              "targetConstituent": 42
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 42,
+              "targetConstituent": 43
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 40,
+              "targetConstituent": 44
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 44,
+              "targetConstituent": 45
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 45,
+              "targetConstituent": 46
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 44,
+              "targetConstituent": 47
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 47,
+              "targetConstituent": 48
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 48,
+              "targetConstituent": 49
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 47,
+              "targetConstituent": 50
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 50,
+              "targetConstituent": 51
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 2,
+              "targetConstituent": 52
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 52,
+              "targetConstituent": 53
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 1,
+              "targetConstituent": 54
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 54,
+              "targetConstituent": 55
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 55,
+              "targetConstituent": 56
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 54,
+              "targetConstituent": 57
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 57,
+              "targetConstituent": 58
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 58,
+              "targetConstituent": 59
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 54,
+              "targetConstituent": 60
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 60,
+              "targetConstituent": 61
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 61,
+              "targetConstituent": 62
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 60,
+              "targetConstituent": 63
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 63,
+              "targetConstituent": 64
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 64,
+              "targetConstituent": 65
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 65,
+              "targetConstituent": 66
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 64,
+              "targetConstituent": 67
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 67,
+              "targetConstituent": 68
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 63,
+              "targetConstituent": 69
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 69,
+              "targetConstituent": 70
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 63,
+              "targetConstituent": 71
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 71,
+              "targetConstituent": 72
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 60,
+              "targetConstituent": 73
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 73,
+              "targetConstituent": 74
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 74,
+              "targetConstituent": 75
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 75,
+              "targetConstituent": 76
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 73,
+              "targetConstituent": 77
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 77,
+              "targetConstituent": 78
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 73,
+              "targetConstituent": 79
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 79,
+              "targetConstituent": 80
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 80,
+              "targetConstituent": 81
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 79,
+              "targetConstituent": 82
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 82,
+              "targetConstituent": 83
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 83,
+              "targetConstituent": 84
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 84,
+              "targetConstituent": 85
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 82,
+              "targetConstituent": 86
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 86,
+              "targetConstituent": 87
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 87,
+              "targetConstituent": 88
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 86,
+              "targetConstituent": 89
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 89,
+              "targetConstituent": 90
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 90,
+              "targetConstituent": 91
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 89,
+              "targetConstituent": 92
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 92,
+              "targetConstituent": 93
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 93,
+              "targetConstituent": 94
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 94,
+              "targetConstituent": 95
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 95,
+              "targetConstituent": 96
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 96,
+              "targetConstituent": 97
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 94,
+              "targetConstituent": 98
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 98,
+              "targetConstituent": 99
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 99,
+              "targetConstituent": 100
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 98,
+              "targetConstituent": 101
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 101,
+              "targetConstituent": 102
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 102,
+              "targetConstituent": 103
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 93,
+              "targetConstituent": 104
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 104,
+              "targetConstituent": 105
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 105,
+              "targetConstituent": 106
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 104,
+              "targetConstituent": 107
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 107,
+              "targetConstituent": 108
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 104,
+              "targetConstituent": 109
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 109,
+              "targetConstituent": 110
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 110,
+              "targetConstituent": 111
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 109,
+              "targetConstituent": 112
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 112,
+              "targetConstituent": 113
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 113,
+              "targetConstituent": 114
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 109,
+              "targetConstituent": 115
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 115,
+              "targetConstituent": 116
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 116,
+              "targetConstituent": 117
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 117,
+              "targetConstituent": 118
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 115,
+              "targetConstituent": 119
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 119,
+              "targetConstituent": 120
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 120,
+              "targetConstituent": 121
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 119,
+              "targetConstituent": 122
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 122,
+              "targetConstituent": 123
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 123,
+              "targetConstituent": 124
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 124,
+              "targetConstituent": 125
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 123,
+              "targetConstituent": 126
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 126,
+              "targetConstituent": 127
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 123,
+              "targetConstituent": 128
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 128,
+              "targetConstituent": 129
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 122,
+              "targetConstituent": 130
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 130,
+              "targetConstituent": 131
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 109,
+              "targetConstituent": 132
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 132,
+              "targetConstituent": 133
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 133,
+              "targetConstituent": 134
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 132,
+              "targetConstituent": 135
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 135,
+              "targetConstituent": 136
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 136,
+              "targetConstituent": 137
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 135,
+              "targetConstituent": 138
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 138,
+              "targetConstituent": 139
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 135,
+              "targetConstituent": 140
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 140,
+              "targetConstituent": 141
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 135,
+              "targetConstituent": 142
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 142,
+              "targetConstituent": 143
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 135,
+              "targetConstituent": 144
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 144,
+              "targetConstituent": 145
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 86,
+              "targetConstituent": 146
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 146,
+              "targetConstituent": 147
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 147,
+              "targetConstituent": 148
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 146,
+              "targetConstituent": 149
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 149,
+              "targetConstituent": 150
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 1,
+              "targetConstituent": 151
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 151,
+              "targetConstituent": 152
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 153,
+              "targetConstituent": 154
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 154,
+              "targetConstituent": 155
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 155,
+              "targetConstituent": 156
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 156,
+              "targetConstituent": 157
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 157,
+              "targetConstituent": 158
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 156,
+              "targetConstituent": 159
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 159,
+              "targetConstituent": 160
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 155,
+              "targetConstituent": 161
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 161,
+              "targetConstituent": 162
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 154,
+              "targetConstituent": 163
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 163,
+              "targetConstituent": 164
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 164,
+              "targetConstituent": 165
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 163,
+              "targetConstituent": 166
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 166,
+              "targetConstituent": 167
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 167,
+              "targetConstituent": 168
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 166,
+              "targetConstituent": 169
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 169,
+              "targetConstituent": 170
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 170,
+              "targetConstituent": 171
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 171,
+              "targetConstituent": 172
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 170,
+              "targetConstituent": 173
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 173,
+              "targetConstituent": 174
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 169,
+              "targetConstituent": 175
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 175,
+              "targetConstituent": 176
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 176,
+              "targetConstituent": 177
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 175,
+              "targetConstituent": 178
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 178,
+              "targetConstituent": 179
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 179,
+              "targetConstituent": 180
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 180,
+              "targetConstituent": 181
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 179,
+              "targetConstituent": 182
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 182,
+              "targetConstituent": 183
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 179,
+              "targetConstituent": 184
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 184,
+              "targetConstituent": 185
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 178,
+              "targetConstituent": 186
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 186,
+              "targetConstituent": 187
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 178,
+              "targetConstituent": 188
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 188,
+              "targetConstituent": 189
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 189,
+              "targetConstituent": 190
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 154,
+              "targetConstituent": 191
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 191,
+              "targetConstituent": 192
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 193,
+              "targetConstituent": 194
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 194,
+              "targetConstituent": 195
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 195,
+              "targetConstituent": 196
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 196,
+              "targetConstituent": 197
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 197,
+              "targetConstituent": 198
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 194,
+              "targetConstituent": 199
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 199,
+              "targetConstituent": 200
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 194,
+              "targetConstituent": 201
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 201,
+              "targetConstituent": 202
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 202,
+              "targetConstituent": 203
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 203,
+              "targetConstituent": 204
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 204,
+              "targetConstituent": 205
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 205,
+              "targetConstituent": 206
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 204,
+              "targetConstituent": 207
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 207,
+              "targetConstituent": 208
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 203,
+              "targetConstituent": 209
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 209,
+              "targetConstituent": 210
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 202,
+              "targetConstituent": 211
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 211,
+              "targetConstituent": 212
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 212,
+              "targetConstituent": 213
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 211,
+              "targetConstituent": 214
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 214,
+              "targetConstituent": 215
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 215,
+              "targetConstituent": 216
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 202,
+              "targetConstituent": 217
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 217,
+              "targetConstituent": 218
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 202,
+              "targetConstituent": 219
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 219,
+              "targetConstituent": 220
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 201,
+              "targetConstituent": 221
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 221,
+              "targetConstituent": 222
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 222,
+              "targetConstituent": 223
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 201,
+              "targetConstituent": 224
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 224,
+              "targetConstituent": 225
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 225,
+              "targetConstituent": 226
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 224,
+              "targetConstituent": 227
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 227,
+              "targetConstituent": 228
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 228,
+              "targetConstituent": 229
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 227,
+              "targetConstituent": 230
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 230,
+              "targetConstituent": 231
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 231,
+              "targetConstituent": 232
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 230,
+              "targetConstituent": 233
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 233,
+              "targetConstituent": 234
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 230,
+              "targetConstituent": 235
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 235,
+              "targetConstituent": 236
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 236,
+              "targetConstituent": 237
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 237,
+              "targetConstituent": 238
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 236,
+              "targetConstituent": 239
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 239,
+              "targetConstituent": 240
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 236,
+              "targetConstituent": 241
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 241,
+              "targetConstituent": 242
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 235,
+              "targetConstituent": 243
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 243,
+              "targetConstituent": 244
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 244,
+              "targetConstituent": 245
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 245,
+              "targetConstituent": 246
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 244,
+              "targetConstituent": 247
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 247,
+              "targetConstituent": 248
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 248,
+              "targetConstituent": 249
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 249,
+              "targetConstituent": 250
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 248,
+              "targetConstituent": 251
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 251,
+              "targetConstituent": 252
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 247,
+              "targetConstituent": 253
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 253,
+              "targetConstituent": 254
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 254,
+              "targetConstituent": 255
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 253,
+              "targetConstituent": 256
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 256,
+              "targetConstituent": 257
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 257,
+              "targetConstituent": 258
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 244,
+              "targetConstituent": 259
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 259,
+              "targetConstituent": 260
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 260,
+              "targetConstituent": 261
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 259,
+              "targetConstituent": 262
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 262,
+              "targetConstituent": 263
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 263,
+              "targetConstituent": 264
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 194,
+              "targetConstituent": 265
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 265,
+              "targetConstituent": 266
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 267,
+              "targetConstituent": 268
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 268,
+              "targetConstituent": 269
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 269,
+              "targetConstituent": 270
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 270,
+              "targetConstituent": 271
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 271,
+              "targetConstituent": 272
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 272,
+              "targetConstituent": 273
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 270,
+              "targetConstituent": 274
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 274,
+              "targetConstituent": 275
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 275,
+              "targetConstituent": 276
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 274,
+              "targetConstituent": 277
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 277,
+              "targetConstituent": 278
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 278,
+              "targetConstituent": 279
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 279,
+              "targetConstituent": 280
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 278,
+              "targetConstituent": 281
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 281,
+              "targetConstituent": 282
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 277,
+              "targetConstituent": 283
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 283,
+              "targetConstituent": 284
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 284,
+              "targetConstituent": 285
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 285,
+              "targetConstituent": 286
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 283,
+              "targetConstituent": 287
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 287,
+              "targetConstituent": 288
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 288,
+              "targetConstituent": 289
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 289,
+              "targetConstituent": 290
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 269,
+              "targetConstituent": 291
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 291,
+              "targetConstituent": 292
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 269,
+              "targetConstituent": 293
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 293,
+              "targetConstituent": 294
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 269,
+              "targetConstituent": 295
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 295,
+              "targetConstituent": 296
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 296,
+              "targetConstituent": 297
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 269,
+              "targetConstituent": 298
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 298,
+              "targetConstituent": 299
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 299,
+              "targetConstituent": 300
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 300,
+              "targetConstituent": 301
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 299,
+              "targetConstituent": 302
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 302,
+              "targetConstituent": 303
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 303,
+              "targetConstituent": 304
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 304,
+              "targetConstituent": 305
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 305,
+              "targetConstituent": 306
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 306,
+              "targetConstituent": 307
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 305,
+              "targetConstituent": 308
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 308,
+              "targetConstituent": 309
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 304,
+              "targetConstituent": 310
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 310,
+              "targetConstituent": 311
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 311,
+              "targetConstituent": 312
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 302,
+              "targetConstituent": 313
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 313,
+              "targetConstituent": 314
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 302,
+              "targetConstituent": 315
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 315,
+              "targetConstituent": 316
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 302,
+              "targetConstituent": 317
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 317,
+              "targetConstituent": 318
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 318,
+              "targetConstituent": 319
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 319,
+              "targetConstituent": 320
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 317,
+              "targetConstituent": 321
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 321,
+              "targetConstituent": 322
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 322,
+              "targetConstituent": 323
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 323,
+              "targetConstituent": 324
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 322,
+              "targetConstituent": 325
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 325,
+              "targetConstituent": 326
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 326,
+              "targetConstituent": 327
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 327,
+              "targetConstituent": 328
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 325,
+              "targetConstituent": 329
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 329,
+              "targetConstituent": 330
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 330,
+              "targetConstituent": 331
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 329,
+              "targetConstituent": 332
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 332,
+              "targetConstituent": 333
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 333,
+              "targetConstituent": 334
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 269,
+              "targetConstituent": 335
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 335,
+              "targetConstituent": 336
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 269,
+              "targetConstituent": 337
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 337,
+              "targetConstituent": 338
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 268,
+              "targetConstituent": 339
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 339,
+              "targetConstituent": 340
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 340,
+              "targetConstituent": 341
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 339,
+              "targetConstituent": 342
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 342,
+              "targetConstituent": 343
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 268,
+              "targetConstituent": 344
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 344,
+              "targetConstituent": 345
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 345,
+              "targetConstituent": 346
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 268,
+              "targetConstituent": 347
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 347,
+              "targetConstituent": 348
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 349,
+              "targetConstituent": 350
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 350,
+              "targetConstituent": 351
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 351,
+              "targetConstituent": 352
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 352,
+              "targetConstituent": 353
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 350,
+              "targetConstituent": 354
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 354,
+              "targetConstituent": 355
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 355,
+              "targetConstituent": 356
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 354,
+              "targetConstituent": 357
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 357,
+              "targetConstituent": 358
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 358,
+              "targetConstituent": 359
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 357,
+              "targetConstituent": 360
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 360,
+              "targetConstituent": 361
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 361,
+              "targetConstituent": 362
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 362,
+              "targetConstituent": 363
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 361,
+              "targetConstituent": 364
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 364,
+              "targetConstituent": 365
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 360,
+              "targetConstituent": 366
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 366,
+              "targetConstituent": 367
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 367,
+              "targetConstituent": 368
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 366,
+              "targetConstituent": 369
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 369,
+              "targetConstituent": 370
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 366,
+              "targetConstituent": 371
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 371,
+              "targetConstituent": 372
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 366,
+              "targetConstituent": 373
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 373,
+              "targetConstituent": 374
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 374,
+              "targetConstituent": 375
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 375,
+              "targetConstituent": 376
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 374,
+              "targetConstituent": 377
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 377,
+              "targetConstituent": 378
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 373,
+              "targetConstituent": 379
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 379,
+              "targetConstituent": 380
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 380,
+              "targetConstituent": 381
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 379,
+              "targetConstituent": 382
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 382,
+              "targetConstituent": 383
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 383,
+              "targetConstituent": 384
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 384,
+              "targetConstituent": 385
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 382,
+              "targetConstituent": 386
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 386,
+              "targetConstituent": 387
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 382,
+              "targetConstituent": 388
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 388,
+              "targetConstituent": 389
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 389,
+              "targetConstituent": 390
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 388,
+              "targetConstituent": 391
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 391,
+              "targetConstituent": 392
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 392,
+              "targetConstituent": 393
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 393,
+              "targetConstituent": 394
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 391,
+              "targetConstituent": 395
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 395,
+              "targetConstituent": 396
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 396,
+              "targetConstituent": 397
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 395,
+              "targetConstituent": 398
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 398,
+              "targetConstituent": 399
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 399,
+              "targetConstituent": 400
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 398,
+              "targetConstituent": 401
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 401,
+              "targetConstituent": 402
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 402,
+              "targetConstituent": 403
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 403,
+              "targetConstituent": 404
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 402,
+              "targetConstituent": 405
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 405,
+              "targetConstituent": 406
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 406,
+              "targetConstituent": 407
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 405,
+              "targetConstituent": 408
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 408,
+              "targetConstituent": 409
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 409,
+              "targetConstituent": 410
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 410,
+              "targetConstituent": 411
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 411,
+              "targetConstituent": 412
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 410,
+              "targetConstituent": 413
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 413,
+              "targetConstituent": 414
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 409,
+              "targetConstituent": 415
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 415,
+              "targetConstituent": 416
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 416,
+              "targetConstituent": 417
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 350,
+              "targetConstituent": 418
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 418,
+              "targetConstituent": 419
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 350,
+              "targetConstituent": 420
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 420,
+              "targetConstituent": 421
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 422,
+              "targetConstituent": 423
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 423,
+              "targetConstituent": 424
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 424,
+              "targetConstituent": 425
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 425,
+              "targetConstituent": 426
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 423,
+              "targetConstituent": 427
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 427,
+              "targetConstituent": 428
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 428,
+              "targetConstituent": 429
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 427,
+              "targetConstituent": 430
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 430,
+              "targetConstituent": 431
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 431,
+              "targetConstituent": 432
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 430,
+              "targetConstituent": 433
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 433,
+              "targetConstituent": 434
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 434,
+              "targetConstituent": 435
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 435,
+              "targetConstituent": 436
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 436,
+              "targetConstituent": 437
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 435,
+              "targetConstituent": 438
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 438,
+              "targetConstituent": 439
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 434,
+              "targetConstituent": 440
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 440,
+              "targetConstituent": 441
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 441,
+              "targetConstituent": 442
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 440,
+              "targetConstituent": 443
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 443,
+              "targetConstituent": 444
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 444,
+              "targetConstituent": 445
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 443,
+              "targetConstituent": 446
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 446,
+              "targetConstituent": 447
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 443,
+              "targetConstituent": 448
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 448,
+              "targetConstituent": 449
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 443,
+              "targetConstituent": 450
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 450,
+              "targetConstituent": 451
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 443,
+              "targetConstituent": 452
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 452,
+              "targetConstituent": 453
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 433,
+              "targetConstituent": 454
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 454,
+              "targetConstituent": 455
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 455,
+              "targetConstituent": 456
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 454,
+              "targetConstituent": 457
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 457,
+              "targetConstituent": 458
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 458,
+              "targetConstituent": 459
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 423,
+              "targetConstituent": 460
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 460,
+              "targetConstituent": 461
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 462,
+              "targetConstituent": 463
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 463,
+              "targetConstituent": 464
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 464,
+              "targetConstituent": 465
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 465,
+              "targetConstituent": 466
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 463,
+              "targetConstituent": 467
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 467,
+              "targetConstituent": 468
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 468,
+              "targetConstituent": 469
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 467,
+              "targetConstituent": 470
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 470,
+              "targetConstituent": 471
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 471,
+              "targetConstituent": 472
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 472,
+              "targetConstituent": 473
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 473,
+              "targetConstituent": 474
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 471,
+              "targetConstituent": 475
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 475,
+              "targetConstituent": 476
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 476,
+              "targetConstituent": 477
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 475,
+              "targetConstituent": 478
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 478,
+              "targetConstituent": 479
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 475,
+              "targetConstituent": 480
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 480,
+              "targetConstituent": 481
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 481,
+              "targetConstituent": 482
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 480,
+              "targetConstituent": 483
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 483,
+              "targetConstituent": 484
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 484,
+              "targetConstituent": 485
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 483,
+              "targetConstituent": 486
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 486,
+              "targetConstituent": 487
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 487,
+              "targetConstituent": 488
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 486,
+              "targetConstituent": 489
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 489,
+              "targetConstituent": 490
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 483,
+              "targetConstituent": 491
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 491,
+              "targetConstituent": 492
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 483,
+              "targetConstituent": 493
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 493,
+              "targetConstituent": 494
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 494,
+              "targetConstituent": 495
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 495,
+              "targetConstituent": 496
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 493,
+              "targetConstituent": 497
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 497,
+              "targetConstituent": 498
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 493,
+              "targetConstituent": 499
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 499,
+              "targetConstituent": 500
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 500,
+              "targetConstituent": 501
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 480,
+              "targetConstituent": 502
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 502,
+              "targetConstituent": 503
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 503,
+              "targetConstituent": 504
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 463,
+              "targetConstituent": 505
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 505,
+              "targetConstituent": 506
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 507,
+              "targetConstituent": 508
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 508,
+              "targetConstituent": 509
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 509,
+              "targetConstituent": 510
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 510,
+              "targetConstituent": 511
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 511,
+              "targetConstituent": 512
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 509,
+              "targetConstituent": 513
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 513,
+              "targetConstituent": 514
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 514,
+              "targetConstituent": 515
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 513,
+              "targetConstituent": 516
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 516,
+              "targetConstituent": 517
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 517,
+              "targetConstituent": 518
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 516,
+              "targetConstituent": 519
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 519,
+              "targetConstituent": 520
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 520,
+              "targetConstituent": 521
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 521,
+              "targetConstituent": 522
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 522,
+              "targetConstituent": 523
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 521,
+              "targetConstituent": 524
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 524,
+              "targetConstituent": 525
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 521,
+              "targetConstituent": 526
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 526,
+              "targetConstituent": 527
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 521,
+              "targetConstituent": 528
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 528,
+              "targetConstituent": 529
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 520,
+              "targetConstituent": 530
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 530,
+              "targetConstituent": 531
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 531,
+              "targetConstituent": 532
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 530,
+              "targetConstituent": 533
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 533,
+              "targetConstituent": 534
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 534,
+              "targetConstituent": 535
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 533,
+              "targetConstituent": 536
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 536,
+              "targetConstituent": 537
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 519,
+              "targetConstituent": 538
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 538,
+              "targetConstituent": 539
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 539,
+              "targetConstituent": 540
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 538,
+              "targetConstituent": 541
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 541,
+              "targetConstituent": 542
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 542,
+              "targetConstituent": 543
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 541,
+              "targetConstituent": 544
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 544,
+              "targetConstituent": 545
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 545,
+              "targetConstituent": 546
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 541,
+              "targetConstituent": 547
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 547,
+              "targetConstituent": 548
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 548,
+              "targetConstituent": 549
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 547,
+              "targetConstituent": 550
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 550,
+              "targetConstituent": 551
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 551,
+              "targetConstituent": 552
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 550,
+              "targetConstituent": 553
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 553,
+              "targetConstituent": 554
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 554,
+              "targetConstituent": 555
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 508,
+              "targetConstituent": 556
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 556,
+              "targetConstituent": 557
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 508,
+              "targetConstituent": 558
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 558,
+              "targetConstituent": 559
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 559,
+              "targetConstituent": 560
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 558,
+              "targetConstituent": 561
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 561,
+              "targetConstituent": 562
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 508,
+              "targetConstituent": 563
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 563,
+              "targetConstituent": 564
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 564,
+              "targetConstituent": 565
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 563,
+              "targetConstituent": 566
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 566,
+              "targetConstituent": 567
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 567,
+              "targetConstituent": 568
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 566,
+              "targetConstituent": 569
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 569,
+              "targetConstituent": 570
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 570,
+              "targetConstituent": 571
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 569,
+              "targetConstituent": 572
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 572,
+              "targetConstituent": 573
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 569,
+              "targetConstituent": 574
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 574,
+              "targetConstituent": 575
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 569,
+              "targetConstituent": 576
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 576,
+              "targetConstituent": 577
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 566,
+              "targetConstituent": 578
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 578,
+              "targetConstituent": 579
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 579,
+              "targetConstituent": 580
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 578,
+              "targetConstituent": 581
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 581,
+              "targetConstituent": 582
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 582,
+              "targetConstituent": 583
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 508,
+              "targetConstituent": 584
+            },
+            {
+              "relationName": "ParentOf",
+              "score": 1.0,
+              "srcConstituent": 584,
+              "targetConstituent": 585
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "viewName": "POS",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.TokenLabelView",
+          "viewName": "POS",
+          "generator": "edu.illinois.cs.cogcomp.pos.POSAnnotator",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 0,
+              "end": 1
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 1,
+              "end": 2
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 2,
+              "end": 3
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 3,
+              "end": 4
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 4,
+              "end": 5
+            },
+            {
+              "label": "WP$",
+              "score": 1.0,
+              "start": 5,
+              "end": 6
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 6,
+              "end": 7
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 7,
+              "end": 8
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 8,
+              "end": 9
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 9,
+              "end": 10
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 10,
+              "end": 11
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 11,
+              "end": 12
+            },
+            {
+              "label": "VB",
+              "score": 1.0,
+              "start": 12,
+              "end": 13
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 13,
+              "end": 14
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 14,
+              "end": 15
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 15,
+              "end": 16
+            },
+            {
+              "label": "CD",
+              "score": 1.0,
+              "start": 16,
+              "end": 17
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 17,
+              "end": 18
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 18,
+              "end": 19
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 19,
+              "end": 20
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 20,
+              "end": 21
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 21,
+              "end": 22
+            },
+            {
+              "label": "POS",
+              "score": 1.0,
+              "start": 22,
+              "end": 23
+            },
+            {
+              "label": "``",
+              "score": 1.0,
+              "start": 23,
+              "end": 24
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 24,
+              "end": 25
+            },
+            {
+              "label": "NNS",
+              "score": 1.0,
+              "start": 25,
+              "end": 26
+            },
+            {
+              "label": "\u0027\u0027",
+              "score": 1.0,
+              "start": 26,
+              "end": 27
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 27,
+              "end": 28
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 28,
+              "end": 29
+            },
+            {
+              "label": "VBZ",
+              "score": 1.0,
+              "start": 29,
+              "end": 30
+            },
+            {
+              "label": "VBN",
+              "score": 1.0,
+              "start": 30,
+              "end": 31
+            },
+            {
+              "label": "NNPS",
+              "score": 1.0,
+              "start": 31,
+              "end": 32
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 32,
+              "end": 33
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 33,
+              "end": 34
+            },
+            {
+              "label": "VBP",
+              "score": 1.0,
+              "start": 34,
+              "end": 35
+            },
+            {
+              "label": "RB",
+              "score": 1.0,
+              "start": 35,
+              "end": 36
+            },
+            {
+              "label": "VBN",
+              "score": 1.0,
+              "start": 36,
+              "end": 37
+            },
+            {
+              "label": "JJR",
+              "score": 1.0,
+              "start": 37,
+              "end": 38
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 38,
+              "end": 39
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 39,
+              "end": 40
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 40,
+              "end": 41
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 41,
+              "end": 42
+            },
+            {
+              "label": "POS",
+              "score": 1.0,
+              "start": 42,
+              "end": 43
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 43,
+              "end": 44
+            },
+            {
+              "label": "TO",
+              "score": 1.0,
+              "start": 44,
+              "end": 45
+            },
+            {
+              "label": "VB",
+              "score": 1.0,
+              "start": 45,
+              "end": 46
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 46,
+              "end": 47
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 47,
+              "end": 48
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 48,
+              "end": 49
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 49,
+              "end": 50
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 50,
+              "end": 51
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 51,
+              "end": 52
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 52,
+              "end": 53
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 53,
+              "end": 54
+            },
+            {
+              "label": "POS",
+              "score": 1.0,
+              "start": 54,
+              "end": 55
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 55,
+              "end": 56
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 56,
+              "end": 57
+            },
+            {
+              "label": "VBG",
+              "score": 1.0,
+              "start": 57,
+              "end": 58
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 58,
+              "end": 59
+            },
+            {
+              "label": "NNS",
+              "score": 1.0,
+              "start": 59,
+              "end": 60
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 60,
+              "end": 61
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 61,
+              "end": 62
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 62,
+              "end": 63
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 63,
+              "end": 64
+            },
+            {
+              "label": "CC",
+              "score": 1.0,
+              "start": 64,
+              "end": 65
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 65,
+              "end": 66
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 66,
+              "end": 67
+            },
+            {
+              "label": "VBN",
+              "score": 1.0,
+              "start": 67,
+              "end": 68
+            },
+            {
+              "label": ":",
+              "score": 1.0,
+              "start": 68,
+              "end": 69
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 69,
+              "end": 70
+            },
+            {
+              "label": "POS",
+              "score": 1.0,
+              "start": 70,
+              "end": 71
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 71,
+              "end": 72
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 72,
+              "end": 73
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 73,
+              "end": 74
+            },
+            {
+              "label": ":",
+              "score": 1.0,
+              "start": 74,
+              "end": 75
+            },
+            {
+              "label": "\u0027\u0027",
+              "score": 1.0,
+              "start": 75,
+              "end": 76
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 76,
+              "end": 77
+            },
+            {
+              "label": "VBP",
+              "score": 1.0,
+              "start": 77,
+              "end": 78
+            },
+            {
+              "label": "VBN",
+              "score": 1.0,
+              "start": 78,
+              "end": 79
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 79,
+              "end": 80
+            },
+            {
+              "label": "\u0027\u0027",
+              "score": 1.0,
+              "start": 80,
+              "end": 81
+            },
+            {
+              "label": "VBG",
+              "score": 1.0,
+              "start": 81,
+              "end": 82
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 82,
+              "end": 83
+            },
+            {
+              "label": "NNS",
+              "score": 1.0,
+              "start": 83,
+              "end": 84
+            },
+            {
+              "label": "``",
+              "score": 1.0,
+              "start": 84,
+              "end": 85
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 85,
+              "end": 86
+            },
+            {
+              "label": "NNPS",
+              "score": 1.0,
+              "start": 86,
+              "end": 87
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 87,
+              "end": 88
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 88,
+              "end": 89
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 89,
+              "end": 90
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 90,
+              "end": 91
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 91,
+              "end": 92
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 92,
+              "end": 93
+            },
+            {
+              "label": "VBP",
+              "score": 1.0,
+              "start": 93,
+              "end": 94
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 94,
+              "end": 95
+            },
+            {
+              "label": "NNS",
+              "score": 1.0,
+              "start": 95,
+              "end": 96
+            },
+            {
+              "label": "WP",
+              "score": 1.0,
+              "start": 96,
+              "end": 97
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 97,
+              "end": 98
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 98,
+              "end": 99
+            },
+            {
+              "label": "\u0027\u0027",
+              "score": 1.0,
+              "start": 99,
+              "end": 100
+            },
+            {
+              "label": "WP",
+              "score": 1.0,
+              "start": 100,
+              "end": 101
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 101,
+              "end": 102
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 102,
+              "end": 103
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 103,
+              "end": 104
+            },
+            {
+              "label": "VBP",
+              "score": 1.0,
+              "start": 104,
+              "end": 105
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 105,
+              "end": 106
+            },
+            {
+              "label": "CC",
+              "score": 1.0,
+              "start": 106,
+              "end": 107
+            },
+            {
+              "label": "WRB",
+              "score": 1.0,
+              "start": 107,
+              "end": 108
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 108,
+              "end": 109
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 109,
+              "end": 110
+            },
+            {
+              "label": "VBP",
+              "score": 1.0,
+              "start": 110,
+              "end": 111
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 111,
+              "end": 112
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 112,
+              "end": 113
+            },
+            {
+              "label": "\u0027\u0027",
+              "score": 1.0,
+              "start": 113,
+              "end": 114
+            },
+            {
+              "label": "``",
+              "score": 1.0,
+              "start": 114,
+              "end": 115
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 115,
+              "end": 116
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 116,
+              "end": 117
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 117,
+              "end": 118
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 118,
+              "end": 119
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 119,
+              "end": 120
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 120,
+              "end": 121
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 121,
+              "end": 122
+            },
+            {
+              "label": "NNPS",
+              "score": 1.0,
+              "start": 122,
+              "end": 123
+            },
+            {
+              "label": "VBN",
+              "score": 1.0,
+              "start": 123,
+              "end": 124
+            },
+            {
+              "label": "CC",
+              "score": 1.0,
+              "start": 124,
+              "end": 125
+            },
+            {
+              "label": "VBN",
+              "score": 1.0,
+              "start": 125,
+              "end": 126
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 126,
+              "end": 127
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 127,
+              "end": 128
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 128,
+              "end": 129
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 129,
+              "end": 130
+            },
+            {
+              "label": "``",
+              "score": 1.0,
+              "start": 130,
+              "end": 131
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 131,
+              "end": 132
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 132,
+              "end": 133
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 133,
+              "end": 134
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 134,
+              "end": 135
+            },
+            {
+              "label": "TO",
+              "score": 1.0,
+              "start": 135,
+              "end": 136
+            },
+            {
+              "label": "VB",
+              "score": 1.0,
+              "start": 136,
+              "end": 137
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 137,
+              "end": 138
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 138,
+              "end": 139
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 139,
+              "end": 140
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 140,
+              "end": 141
+            },
+            {
+              "label": "\u0027\u0027",
+              "score": 1.0,
+              "start": 141,
+              "end": 142
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 142,
+              "end": 143
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 143,
+              "end": 144
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 144,
+              "end": 145
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 145,
+              "end": 146
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 146,
+              "end": 147
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 147,
+              "end": 148
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 148,
+              "end": 149
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 149,
+              "end": 150
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 150,
+              "end": 151
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 151,
+              "end": 152
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 152,
+              "end": 153
+            },
+            {
+              "label": "MD",
+              "score": 1.0,
+              "start": 153,
+              "end": 154
+            },
+            {
+              "label": "VB",
+              "score": 1.0,
+              "start": 154,
+              "end": 155
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 155,
+              "end": 156
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 156,
+              "end": 157
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 157,
+              "end": 158
+            },
+            {
+              "label": "EX",
+              "score": 1.0,
+              "start": 158,
+              "end": 159
+            },
+            {
+              "label": "VBZ",
+              "score": 1.0,
+              "start": 159,
+              "end": 160
+            },
+            {
+              "label": "RB",
+              "score": 1.0,
+              "start": 160,
+              "end": 161
+            },
+            {
+              "label": "VBN",
+              "score": 1.0,
+              "start": 161,
+              "end": 162
+            },
+            {
+              "label": "``",
+              "score": 1.0,
+              "start": 162,
+              "end": 163
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 163,
+              "end": 164
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 164,
+              "end": 165
+            },
+            {
+              "label": "\u0027\u0027",
+              "score": 1.0,
+              "start": 165,
+              "end": 166
+            },
+            {
+              "label": "RB",
+              "score": 1.0,
+              "start": 166,
+              "end": 167
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 167,
+              "end": 168
+            },
+            {
+              "label": "NNPS",
+              "score": 1.0,
+              "start": 168,
+              "end": 169
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 169,
+              "end": 170
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 170,
+              "end": 171
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 171,
+              "end": 172
+            },
+            {
+              "label": "VBD",
+              "score": 1.0,
+              "start": 172,
+              "end": 173
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 173,
+              "end": 174
+            },
+            {
+              "label": "``",
+              "score": 1.0,
+              "start": 174,
+              "end": 175
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 175,
+              "end": 176
+            },
+            {
+              "label": "\u0027\u0027",
+              "score": 1.0,
+              "start": 176,
+              "end": 177
+            },
+            {
+              "label": "NNS",
+              "score": 1.0,
+              "start": 177,
+              "end": 178
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 178,
+              "end": 179
+            },
+            {
+              "label": "DT",
+              "score": 1.0,
+              "start": 179,
+              "end": 180
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 180,
+              "end": 181
+            },
+            {
+              "label": "VBP",
+              "score": 1.0,
+              "start": 181,
+              "end": 182
+            },
+            {
+              "label": "VBN",
+              "score": 1.0,
+              "start": 182,
+              "end": 183
+            },
+            {
+              "label": "RB",
+              "score": 1.0,
+              "start": 183,
+              "end": 184
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 184,
+              "end": 185
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 185,
+              "end": 186
+            },
+            {
+              "label": "NNP",
+              "score": 1.0,
+              "start": 186,
+              "end": 187
+            },
+            {
+              "label": ",",
+              "score": 1.0,
+              "start": 187,
+              "end": 188
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 188,
+              "end": 189
+            },
+            {
+              "label": "NN",
+              "score": 1.0,
+              "start": 189,
+              "end": 190
+            },
+            {
+              "label": "VBZ",
+              "score": 1.0,
+              "start": 190,
+              "end": 191
+            },
+            {
+              "label": "VBN",
+              "score": 1.0,
+              "start": 191,
+              "end": 192
+            },
+            {
+              "label": "CC",
+              "score": 1.0,
+              "start": 192,
+              "end": 193
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 193,
+              "end": 194
+            },
+            {
+              "label": "CC",
+              "score": 1.0,
+              "start": 194,
+              "end": 195
+            },
+            {
+              "label": "JJ",
+              "score": 1.0,
+              "start": 195,
+              "end": 196
+            },
+            {
+              "label": "IN",
+              "score": 1.0,
+              "start": 196,
+              "end": 197
+            },
+            {
+              "label": "PRP",
+              "score": 1.0,
+              "start": 197,
+              "end": 198
+            },
+            {
+              "label": ".",
+              "score": 1.0,
+              "start": 198,
+              "end": 199
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "viewName": "QUANTITIES",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.SpanLabelView",
+          "viewName": "QUANTITIES",
+          "generator": "illinois-quantifier",
+          "score": 1.0
+        }
+      ]
+    },
+    {
+      "viewName": "SHALLOW_PARSE",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.SpanLabelView",
+          "viewName": "SHALLOW_PARSE",
+          "generator": "edu.illinois.cs.cogcomp.chunker.main.ChunkerAnnotator",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 0,
+              "end": 1
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 2,
+              "end": 5
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 5,
+              "end": 7
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 7,
+              "end": 8
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 8,
+              "end": 11
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 11,
+              "end": 13
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 13,
+              "end": 14
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 14,
+              "end": 15
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 15,
+              "end": 17
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 18,
+              "end": 19
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 19,
+              "end": 20
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 20,
+              "end": 21
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 21,
+              "end": 22
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 22,
+              "end": 26
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 27,
+              "end": 28
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 28,
+              "end": 29
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 29,
+              "end": 30
+            },
+            {
+              "label": "ADJP",
+              "score": 1.0,
+              "start": 30,
+              "end": 32
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 32,
+              "end": 33
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 33,
+              "end": 34
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 34,
+              "end": 37
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 37,
+              "end": 39
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 39,
+              "end": 40
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 40,
+              "end": 42
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 42,
+              "end": 44
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 44,
+              "end": 46
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 46,
+              "end": 50
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 50,
+              "end": 52
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 53,
+              "end": 54
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 54,
+              "end": 56
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 56,
+              "end": 58
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 58,
+              "end": 60
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 60,
+              "end": 61
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 61,
+              "end": 66
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 67,
+              "end": 68
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 69,
+              "end": 70
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 70,
+              "end": 72
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 72,
+              "end": 73
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 73,
+              "end": 74
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 76,
+              "end": 77
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 77,
+              "end": 79
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 79,
+              "end": 80
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 80,
+              "end": 84
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 85,
+              "end": 87
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 87,
+              "end": 88
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 88,
+              "end": 89
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 89,
+              "end": 90
+            },
+            {
+              "label": "ADJP",
+              "score": 1.0,
+              "start": 90,
+              "end": 91
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 92,
+              "end": 93
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 93,
+              "end": 94
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 94,
+              "end": 96
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 96,
+              "end": 97
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 97,
+              "end": 98
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 100,
+              "end": 101
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 102,
+              "end": 104
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 104,
+              "end": 105
+            },
+            {
+              "label": "ADVP",
+              "score": 1.0,
+              "start": 107,
+              "end": 108
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 109,
+              "end": 110
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 110,
+              "end": 111
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 111,
+              "end": 112
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 115,
+              "end": 116
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 116,
+              "end": 117
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 118,
+              "end": 119
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 119,
+              "end": 120
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 120,
+              "end": 121
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 121,
+              "end": 123
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 123,
+              "end": 126
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 126,
+              "end": 128
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 128,
+              "end": 129
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 129,
+              "end": 130
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 131,
+              "end": 132
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 132,
+              "end": 133
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 133,
+              "end": 134
+            },
+            {
+              "label": "ADJP",
+              "score": 1.0,
+              "start": 134,
+              "end": 135
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 135,
+              "end": 137
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 137,
+              "end": 139
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 139,
+              "end": 140
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 142,
+              "end": 143
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 143,
+              "end": 144
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 144,
+              "end": 145
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 145,
+              "end": 147
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 147,
+              "end": 148
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 148,
+              "end": 153
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 153,
+              "end": 155
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 156,
+              "end": 157
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 157,
+              "end": 158
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 158,
+              "end": 159
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 159,
+              "end": 162
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 163,
+              "end": 164
+            },
+            {
+              "label": "ADJP",
+              "score": 1.0,
+              "start": 164,
+              "end": 165
+            },
+            {
+              "label": "ADVP",
+              "score": 1.0,
+              "start": 166,
+              "end": 167
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 167,
+              "end": 168
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 168,
+              "end": 169
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 169,
+              "end": 170
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 171,
+              "end": 172
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 172,
+              "end": 173
+            },
+            {
+              "label": "SBAR",
+              "score": 1.0,
+              "start": 173,
+              "end": 174
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 174,
+              "end": 178
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 178,
+              "end": 179
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 179,
+              "end": 181
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 181,
+              "end": 183
+            },
+            {
+              "label": "ADJP",
+              "score": 1.0,
+              "start": 183,
+              "end": 185
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 185,
+              "end": 186
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 186,
+              "end": 187
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 188,
+              "end": 190
+            },
+            {
+              "label": "VP",
+              "score": 1.0,
+              "start": 190,
+              "end": 193
+            },
+            {
+              "label": "ADJP",
+              "score": 1.0,
+              "start": 193,
+              "end": 196
+            },
+            {
+              "label": "PP",
+              "score": 1.0,
+              "start": 196,
+              "end": 197
+            },
+            {
+              "label": "NP",
+              "score": 1.0,
+              "start": 197,
+              "end": 198
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "viewName": "SRL_NOM",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.PredicateArgumentView",
+          "viewName": "SRL_NOM",
+          "generator": "illinoisSRL-nom5.4.1",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 4,
+              "end": 5,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "contributor"
+              }
+            },
+            {
+              "label": "A2",
+              "score": 1.0,
+              "start": 3,
+              "end": 4
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 6,
+              "end": 7,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "reporting"
+              }
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 7,
+              "end": 11
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 38,
+              "end": 39,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "skepticism"
+              }
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 39,
+              "end": 44
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 43,
+              "end": 44,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "decision"
+              }
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 40,
+              "end": 43
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 55,
+              "end": 56,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "department"
+              }
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 53,
+              "end": 55
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 59,
+              "end": 60,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "tie"
+              }
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 60,
+              "end": 66
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 63,
+              "end": 64,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "campaign"
+              }
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 62,
+              "end": 63
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 71,
+              "end": 72,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "chief"
+              }
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 83,
+              "end": 84,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "law"
+              }
+            },
+            {
+              "label": "A3",
+              "score": 1.0,
+              "start": 81,
+              "end": 82
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 82,
+              "end": 83
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 127,
+              "end": 128,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "impeachment"
+              }
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 146,
+              "end": 147,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "trial"
+              }
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 147,
+              "end": 153
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 177,
+              "end": 178,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "member"
+              }
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 189,
+              "end": 190,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "leadership"
+              }
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 188,
+              "end": 189
+            }
+          ],
+          "relations": [
+            {
+              "relationName": "A2",
+              "srcConstituent": 0,
+              "targetConstituent": 1
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 2,
+              "targetConstituent": 3
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 4,
+              "targetConstituent": 5
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 6,
+              "targetConstituent": 7
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 8,
+              "targetConstituent": 9
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 10,
+              "targetConstituent": 11
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 12,
+              "targetConstituent": 13
+            },
+            {
+              "relationName": "A3",
+              "srcConstituent": 15,
+              "targetConstituent": 16
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 15,
+              "targetConstituent": 17
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 19,
+              "targetConstituent": 20
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 22,
+              "targetConstituent": 23
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "viewName": "SRL_VERB",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.PredicateArgumentView",
+          "viewName": "SRL_VERB",
+          "generator": "illinoisSRL-verb5.4.1",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 11,
+              "end": 12,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "help"
+              }
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 5,
+              "end": 11
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 12,
+              "end": 17
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 12,
+              "end": 13,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "topple"
+              }
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 5,
+              "end": 11
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 18,
+              "end": 19,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "say"
+              }
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 20,
+              "end": 52
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 0,
+              "end": 18
+            },
+            {
+              "label": "AM-TMP",
+              "score": 1.0,
+              "start": 19,
+              "end": 20
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 29,
+              "end": 30,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "be"
+              }
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 30,
+              "end": 50
+            },
+            {
+              "label": "A2",
+              "score": 1.0,
+              "start": 28,
+              "end": 29
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 30,
+              "end": 31,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "concern"
+              }
+            },
+            {
+              "label": "A2",
+              "score": 1.0,
+              "start": 28,
+              "end": 29
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 31,
+              "end": 50
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 36,
+              "end": 37,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "voice"
+              }
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 31,
+              "end": 34
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 50,
+              "end": 52
+            },
+            {
+              "label": "AM-DIS",
+              "score": 1.0,
+              "start": 35,
+              "end": 36
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 45,
+              "end": 46,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "fire"
+              }
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 38,
+              "end": 44
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 50,
+              "end": 52
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 57,
+              "end": 58,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "investigate"
+              }
+            },
+            {
+              "label": "AM-MNR",
+              "score": 1.0,
+              "start": 57,
+              "end": 58
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 58,
+              "end": 66
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 53,
+              "end": 56
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 67,
+              "end": 68,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "relate"
+              }
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 67,
+              "end": 92
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 78,
+              "end": 79,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "look"
+              }
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 69,
+              "end": 76
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 79,
+              "end": 91
+            },
+            {
+              "label": "AM-TMP",
+              "score": 1.0,
+              "start": 76,
+              "end": 77
+            },
+            {
+              "label": "AM-ADV",
+              "score": 1.0,
+              "start": 78,
+              "end": 79
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 81,
+              "end": 82,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "change"
+              }
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 84,
+              "end": 91
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 81,
+              "end": 84
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 89,
+              "end": 90,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "be"
+              }
+            },
+            {
+              "label": "AM-MNR",
+              "score": 1.0,
+              "start": 90,
+              "end": 91
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 85,
+              "end": 89
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 93,
+              "end": 94,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "be"
+              }
+            },
+            {
+              "label": "AM-ADV",
+              "score": 1.0,
+              "start": 92,
+              "end": 93
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 94,
+              "end": 98
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 97,
+              "end": 98,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "say"
+              }
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 96,
+              "end": 97
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 94,
+              "end": 96
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 101,
+              "end": 102,
+              "properties": {
+                "SenseNumber": "02",
+                "predicate": "do"
+              }
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 100,
+              "end": 101
+            },
+            {
+              "label": "AM-ADV",
+              "score": 1.0,
+              "start": 101,
+              "end": 112
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 104,
+              "end": 105,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "know"
+              }
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 100,
+              "end": 101
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 102,
+              "end": 104
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 108,
+              "end": 109,
+              "properties": {
+                "SenseNumber": "02",
+                "predicate": "do"
+              }
+            },
+            {
+              "label": "AM-DIS",
+              "score": 1.0,
+              "start": 107,
+              "end": 108
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 110,
+              "end": 111,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "know"
+              }
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 111,
+              "end": 112
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 109,
+              "end": 110
+            },
+            {
+              "label": "AM-DIS",
+              "score": 1.0,
+              "start": 107,
+              "end": 108
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 116,
+              "end": 117,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "say"
+              }
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 114,
+              "end": 116
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 92,
+              "end": 114
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 119,
+              "end": 120,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "add"
+              }
+            },
+            {
+              "label": "AM-DIS",
+              "score": 1.0,
+              "start": 119,
+              "end": 120
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 118,
+              "end": 119
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 123,
+              "end": 124,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "investigate"
+              }
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 121,
+              "end": 123
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 125,
+              "end": 126,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "support"
+              }
+            },
+            {
+              "label": "AM-ADV",
+              "score": 1.0,
+              "start": 125,
+              "end": 126
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 126,
+              "end": 140
+            },
+            {
+              "label": "AM-TMP",
+              "score": 1.0,
+              "start": 124,
+              "end": 125
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 121,
+              "end": 123
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 133,
+              "end": 134,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "be"
+              }
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 132,
+              "end": 133
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 136,
+              "end": 137,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "see"
+              }
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 132,
+              "end": 133
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 137,
+              "end": 140
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 139,
+              "end": 140,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "serve"
+              }
+            },
+            {
+              "label": "A2",
+              "score": 1.0,
+              "start": 132,
+              "end": 133
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 136,
+              "end": 137
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 137,
+              "end": 139
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 143,
+              "end": 144,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "resign"
+              }
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 144,
+              "end": 155
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 142,
+              "end": 143
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 154,
+              "end": 155,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "happen"
+              }
+            },
+            {
+              "label": "AM-TMP",
+              "score": 1.0,
+              "start": 154,
+              "end": 155
+            },
+            {
+              "label": "AM-MOD",
+              "score": 1.0,
+              "start": 153,
+              "end": 154
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 145,
+              "end": 153
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 157,
+              "end": 158,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "say"
+              }
+            },
+            {
+              "label": "AM-DIS",
+              "score": 1.0,
+              "start": 157,
+              "end": 158
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 158,
+              "end": 170
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 156,
+              "end": 157
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 161,
+              "end": 162,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "be"
+              }
+            },
+            {
+              "label": "AM-NEG",
+              "score": 1.0,
+              "start": 158,
+              "end": 159
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 162,
+              "end": 169
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 172,
+              "end": 173,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "say"
+              }
+            },
+            {
+              "label": "AM-DIS",
+              "score": 1.0,
+              "start": 172,
+              "end": 173
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 173,
+              "end": 187
+            },
+            {
+              "label": "A0",
+              "score": 1.0,
+              "start": 171,
+              "end": 172
+            },
+            {
+              "label": "Predicate",
+              "score": 1.0,
+              "start": 182,
+              "end": 183,
+              "properties": {
+                "SenseNumber": "01",
+                "predicate": "be"
+              }
+            },
+            {
+              "label": "AM-MNR",
+              "score": 1.0,
+              "start": 183,
+              "end": 184
+            },
+            {
+              "label": "AM-MNR",
+              "score": 1.0,
+              "start": 182,
+              "end": 183
+            },
+            {
+              "label": "A2",
+              "score": 1.0,
+              "start": 184,
+              "end": 187
+            },
+            {
+              "label": "A1",
+              "score": 1.0,
+              "start": 174,
+              "end": 181
+            }
+          ],
+          "relations": [
+            {
+              "relationName": "A0",
+              "srcConstituent": 0,
+              "targetConstituent": 1
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 0,
+              "targetConstituent": 2
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 3,
+              "targetConstituent": 4
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 5,
+              "targetConstituent": 6
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 5,
+              "targetConstituent": 7
+            },
+            {
+              "relationName": "AM-TMP",
+              "srcConstituent": 5,
+              "targetConstituent": 8
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 9,
+              "targetConstituent": 10
+            },
+            {
+              "relationName": "A2",
+              "srcConstituent": 9,
+              "targetConstituent": 11
+            },
+            {
+              "relationName": "A2",
+              "srcConstituent": 12,
+              "targetConstituent": 13
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 12,
+              "targetConstituent": 14
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 15,
+              "targetConstituent": 16
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 15,
+              "targetConstituent": 17
+            },
+            {
+              "relationName": "AM-DIS",
+              "srcConstituent": 15,
+              "targetConstituent": 18
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 19,
+              "targetConstituent": 20
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 19,
+              "targetConstituent": 21
+            },
+            {
+              "relationName": "AM-MNR",
+              "srcConstituent": 22,
+              "targetConstituent": 23
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 22,
+              "targetConstituent": 24
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 22,
+              "targetConstituent": 25
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 26,
+              "targetConstituent": 27
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 28,
+              "targetConstituent": 29
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 28,
+              "targetConstituent": 30
+            },
+            {
+              "relationName": "AM-TMP",
+              "srcConstituent": 28,
+              "targetConstituent": 31
+            },
+            {
+              "relationName": "AM-ADV",
+              "srcConstituent": 28,
+              "targetConstituent": 32
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 33,
+              "targetConstituent": 34
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 33,
+              "targetConstituent": 35
+            },
+            {
+              "relationName": "AM-MNR",
+              "srcConstituent": 36,
+              "targetConstituent": 37
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 36,
+              "targetConstituent": 38
+            },
+            {
+              "relationName": "AM-ADV",
+              "srcConstituent": 39,
+              "targetConstituent": 40
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 39,
+              "targetConstituent": 41
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 42,
+              "targetConstituent": 43
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 42,
+              "targetConstituent": 44
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 45,
+              "targetConstituent": 46
+            },
+            {
+              "relationName": "AM-ADV",
+              "srcConstituent": 45,
+              "targetConstituent": 47
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 48,
+              "targetConstituent": 49
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 48,
+              "targetConstituent": 50
+            },
+            {
+              "relationName": "AM-DIS",
+              "srcConstituent": 51,
+              "targetConstituent": 52
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 53,
+              "targetConstituent": 54
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 53,
+              "targetConstituent": 55
+            },
+            {
+              "relationName": "AM-DIS",
+              "srcConstituent": 53,
+              "targetConstituent": 56
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 57,
+              "targetConstituent": 58
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 57,
+              "targetConstituent": 59
+            },
+            {
+              "relationName": "AM-DIS",
+              "srcConstituent": 60,
+              "targetConstituent": 61
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 60,
+              "targetConstituent": 62
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 63,
+              "targetConstituent": 64
+            },
+            {
+              "relationName": "AM-ADV",
+              "srcConstituent": 65,
+              "targetConstituent": 66
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 65,
+              "targetConstituent": 67
+            },
+            {
+              "relationName": "AM-TMP",
+              "srcConstituent": 65,
+              "targetConstituent": 68
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 65,
+              "targetConstituent": 69
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 70,
+              "targetConstituent": 71
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 72,
+              "targetConstituent": 73
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 72,
+              "targetConstituent": 74
+            },
+            {
+              "relationName": "A2",
+              "srcConstituent": 75,
+              "targetConstituent": 76
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 75,
+              "targetConstituent": 77
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 75,
+              "targetConstituent": 78
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 79,
+              "targetConstituent": 80
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 79,
+              "targetConstituent": 81
+            },
+            {
+              "relationName": "AM-TMP",
+              "srcConstituent": 82,
+              "targetConstituent": 83
+            },
+            {
+              "relationName": "AM-MOD",
+              "srcConstituent": 82,
+              "targetConstituent": 84
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 82,
+              "targetConstituent": 85
+            },
+            {
+              "relationName": "AM-DIS",
+              "srcConstituent": 86,
+              "targetConstituent": 87
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 86,
+              "targetConstituent": 88
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 86,
+              "targetConstituent": 89
+            },
+            {
+              "relationName": "AM-NEG",
+              "srcConstituent": 90,
+              "targetConstituent": 91
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 90,
+              "targetConstituent": 92
+            },
+            {
+              "relationName": "AM-DIS",
+              "srcConstituent": 93,
+              "targetConstituent": 94
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 93,
+              "targetConstituent": 95
+            },
+            {
+              "relationName": "A0",
+              "srcConstituent": 93,
+              "targetConstituent": 96
+            },
+            {
+              "relationName": "AM-MNR",
+              "srcConstituent": 97,
+              "targetConstituent": 98
+            },
+            {
+              "relationName": "AM-MNR",
+              "srcConstituent": 97,
+              "targetConstituent": 99
+            },
+            {
+              "relationName": "A2",
+              "srcConstituent": 97,
+              "targetConstituent": 100
+            },
+            {
+              "relationName": "A1",
+              "srcConstituent": 97,
+              "targetConstituent": 101
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "viewName": "TOKENS",
+      "viewData": [
+        {
+          "viewType": "edu.illinois.cs.cogcomp.core.datastructures.textannotation.TokenLabelView",
+          "viewName": "TOKENS",
+          "generator": "UserSpecified",
+          "score": 1.0,
+          "constituents": [
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 0,
+              "end": 1
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 1,
+              "end": 2
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 2,
+              "end": 3
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 3,
+              "end": 4
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 4,
+              "end": 5
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 5,
+              "end": 6
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 6,
+              "end": 7
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 7,
+              "end": 8
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 8,
+              "end": 9
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 9,
+              "end": 10
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 10,
+              "end": 11
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 11,
+              "end": 12
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 12,
+              "end": 13
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 13,
+              "end": 14
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 14,
+              "end": 15
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 15,
+              "end": 16
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 16,
+              "end": 17
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 17,
+              "end": 18
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 18,
+              "end": 19
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 19,
+              "end": 20
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 20,
+              "end": 21
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 21,
+              "end": 22
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 22,
+              "end": 23
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 23,
+              "end": 24
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 24,
+              "end": 25
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 25,
+              "end": 26
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 26,
+              "end": 27
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 27,
+              "end": 28
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 28,
+              "end": 29
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 29,
+              "end": 30
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 30,
+              "end": 31
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 31,
+              "end": 32
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 32,
+              "end": 33
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 33,
+              "end": 34
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 34,
+              "end": 35
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 35,
+              "end": 36
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 36,
+              "end": 37
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 37,
+              "end": 38
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 38,
+              "end": 39
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 39,
+              "end": 40
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 40,
+              "end": 41
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 41,
+              "end": 42
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 42,
+              "end": 43
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 43,
+              "end": 44
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 44,
+              "end": 45
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 45,
+              "end": 46
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 46,
+              "end": 47
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 47,
+              "end": 48
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 48,
+              "end": 49
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 49,
+              "end": 50
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 50,
+              "end": 51
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 51,
+              "end": 52
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 52,
+              "end": 53
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 53,
+              "end": 54
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 54,
+              "end": 55
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 55,
+              "end": 56
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 56,
+              "end": 57
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 57,
+              "end": 58
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 58,
+              "end": 59
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 59,
+              "end": 60
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 60,
+              "end": 61
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 61,
+              "end": 62
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 62,
+              "end": 63
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 63,
+              "end": 64
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 64,
+              "end": 65
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 65,
+              "end": 66
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 66,
+              "end": 67
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 67,
+              "end": 68
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 68,
+              "end": 69
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 69,
+              "end": 70
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 70,
+              "end": 71
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 71,
+              "end": 72
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 72,
+              "end": 73
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 73,
+              "end": 74
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 74,
+              "end": 75
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 75,
+              "end": 76
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 76,
+              "end": 77
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 77,
+              "end": 78
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 78,
+              "end": 79
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 79,
+              "end": 80
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 80,
+              "end": 81
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 81,
+              "end": 82
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 82,
+              "end": 83
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 83,
+              "end": 84
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 84,
+              "end": 85
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 85,
+              "end": 86
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 86,
+              "end": 87
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 87,
+              "end": 88
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 88,
+              "end": 89
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 89,
+              "end": 90
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 90,
+              "end": 91
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 91,
+              "end": 92
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 92,
+              "end": 93
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 93,
+              "end": 94
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 94,
+              "end": 95
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 95,
+              "end": 96
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 96,
+              "end": 97
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 97,
+              "end": 98
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 98,
+              "end": 99
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 99,
+              "end": 100
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 100,
+              "end": 101
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 101,
+              "end": 102
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 102,
+              "end": 103
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 103,
+              "end": 104
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 104,
+              "end": 105
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 105,
+              "end": 106
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 106,
+              "end": 107
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 107,
+              "end": 108
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 108,
+              "end": 109
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 109,
+              "end": 110
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 110,
+              "end": 111
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 111,
+              "end": 112
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 112,
+              "end": 113
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 113,
+              "end": 114
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 114,
+              "end": 115
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 115,
+              "end": 116
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 116,
+              "end": 117
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 117,
+              "end": 118
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 118,
+              "end": 119
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 119,
+              "end": 120
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 120,
+              "end": 121
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 121,
+              "end": 122
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 122,
+              "end": 123
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 123,
+              "end": 124
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 124,
+              "end": 125
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 125,
+              "end": 126
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 126,
+              "end": 127
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 127,
+              "end": 128
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 128,
+              "end": 129
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 129,
+              "end": 130
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 130,
+              "end": 131
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 131,
+              "end": 132
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 132,
+              "end": 133
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 133,
+              "end": 134
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 134,
+              "end": 135
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 135,
+              "end": 136
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 136,
+              "end": 137
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 137,
+              "end": 138
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 138,
+              "end": 139
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 139,
+              "end": 140
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 140,
+              "end": 141
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 141,
+              "end": 142
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 142,
+              "end": 143
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 143,
+              "end": 144
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 144,
+              "end": 145
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 145,
+              "end": 146
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 146,
+              "end": 147
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 147,
+              "end": 148
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 148,
+              "end": 149
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 149,
+              "end": 150
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 150,
+              "end": 151
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 151,
+              "end": 152
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 152,
+              "end": 153
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 153,
+              "end": 154
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 154,
+              "end": 155
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 155,
+              "end": 156
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 156,
+              "end": 157
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 157,
+              "end": 158
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 158,
+              "end": 159
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 159,
+              "end": 160
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 160,
+              "end": 161
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 161,
+              "end": 162
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 162,
+              "end": 163
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 163,
+              "end": 164
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 164,
+              "end": 165
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 165,
+              "end": 166
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 166,
+              "end": 167
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 167,
+              "end": 168
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 168,
+              "end": 169
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 169,
+              "end": 170
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 170,
+              "end": 171
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 171,
+              "end": 172
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 172,
+              "end": 173
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 173,
+              "end": 174
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 174,
+              "end": 175
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 175,
+              "end": 176
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 176,
+              "end": 177
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 177,
+              "end": 178
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 178,
+              "end": 179
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 179,
+              "end": 180
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 180,
+              "end": 181
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 181,
+              "end": 182
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 182,
+              "end": 183
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 183,
+              "end": 184
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 184,
+              "end": 185
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 185,
+              "end": 186
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 186,
+              "end": 187
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 187,
+              "end": 188
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 188,
+              "end": 189
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 189,
+              "end": 190
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 190,
+              "end": 191
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 191,
+              "end": 192
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 192,
+              "end": 193
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 193,
+              "end": 194
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 194,
+              "end": 195
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 195,
+              "end": 196
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 196,
+              "end": 197
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 197,
+              "end": 198
+            },
+            {
+              "label": "",
+              "score": 1.0,
+              "start": 198,
+              "end": 199
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pipeline/test/testIn.txt
+++ b/pipeline/test/testIn.txt
@@ -1,0 +1,11 @@
+Bernstein, a CNN contributor whose reporting for the Washington Post helped topple Nixon in the 1970s, said Sunday on CNN's "Reliable Sources" that he is concerned Republicans in Congress haven't voiced more skepticism of President Trump's decision to fire FBI Director James Comey last week.
+
+Comey's department was investigating potential ties between the Trump campaign and Russia.
+
+Related: Trump's chief of staff: 'We've looked at' changing libel laws
+
+"The Republicans during Watergate were heroic. They are the ones who said, 'What did the president know, and when did he know it?'" Bernstein said.
+
+He added that those Republicans investigated and supported the impeachment of Nixon "because they were willing to see the truth served." Nixon resigned before a trial in the U.S. Senate could happen.
+
+Bernstein said there has not been "something similar" yet from Republicans today. He said while "numerous" members of the party have been quietly critical of Trump, conservative leadership has been either silent or supportive of him. 


### PR DESCRIPTION
reads extra attribute specified in TAC event argument linking data (`origin`). Updates NER README.md. Adds missing pipeline script and test files. Closes #420. Closes #441. Closes #446.