### PR TITLE
Small fixes for #462

### DIFF
--- a/prepsrl/src/main/java/edu/illinois/cs/cogcomp/prepsrl/PrepSRLAnnotator.java
+++ b/prepsrl/src/main/java/edu/illinois/cs/cogcomp/prepsrl/PrepSRLAnnotator.java
@@ -11,6 +11,7 @@ import edu.illinois.cs.cogcomp.annotation.Annotator;
 import edu.illinois.cs.cogcomp.annotation.AnnotatorException;
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.Constituent;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.SpanLabelView;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TokenLabelView;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
@@ -80,7 +81,7 @@ public class PrepSRLAnnotator extends Annotator {
                 candidates.add(multiWordPrep);
         }
 
-        TokenLabelView prepositionLabelView = new TokenLabelView(viewName, ta);
+        SpanLabelView prepositionLabelView = new SpanLabelView(viewName, viewName + "-annotator", ta, 1.0, true);
         for (Constituent c : candidates) {
             String role = classifier.discreteValue(c);
             if (!role.equals(DataReader.CANDIDATE))

--- a/prepsrl/src/main/java/edu/illinois/cs/cogcomp/prepsrl/inference/ConstrainedPrepSRLClassifier.java
+++ b/prepsrl/src/main/java/edu/illinois/cs/cogcomp/prepsrl/inference/ConstrainedPrepSRLClassifier.java
@@ -75,7 +75,7 @@ public class ConstrainedPrepSRLClassifier extends Classifier {
 
         try {
             result = inference.valueOf(prepSRLClassifier, example);
-        } catch (Exception e) {
+        } catch (AssertionError | Exception e) {
             logger.error
                     ("LBJava ERROR: Fatal error while evaluating classifier ConstrainedPrepSRLClassifier: "
                             + e);


### PR DESCRIPTION
Added an `AssertionError` catcher
Switched PrepSRL view to a `SpanLabelView` since multi-word preposition spans are allowed (also allowing overlapping annotations).