### PR TITLE
adding arguments for prep-srl labels.

### DIFF
--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/PredicateArgumentView.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/PredicateArgumentView.java
@@ -52,7 +52,7 @@ public class PredicateArgumentView extends View {
         this.predicates.add(predicate);
 
         for (int i = 0; i < args.size(); i++) {
-            this.addConstituent(args.get(i));
+            if(!this.containsConstituent(args.get(i))) this.addConstituent(args.get(i));
             this.addRelation(new Relation(relations[i], predicate, args.get(i), scores[i]));
         }
     }

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/View.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/View.java
@@ -150,9 +150,7 @@ public class View implements Serializable, IQueryable<Constituent> {
         endSpan = Math.max(this.endSpan, constituent.getEndSpan());
 
         if (startSpan >= 0 && endSpan >= 0) {
-
             for (int token = constituent.getStartSpan(); token < constituent.getEndSpan(); token++) {
-
                 this.addTokenToConstituentMapping(token, constituent);
             }
         }

--- a/core-utilities/src/test/java/edu/illinois/cs/cogcomp/annotation/TextAnnotationSerializationTest.java
+++ b/core-utilities/src/test/java/edu/illinois/cs/cogcomp/annotation/TextAnnotationSerializationTest.java
@@ -8,7 +8,10 @@
 package edu.illinois.cs.cogcomp.annotation;
 
 import edu.illinois.cs.cogcomp.annotation.BasicTextAnnotationBuilder;
+import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.PredicateArgumentView;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
+import edu.illinois.cs.cogcomp.core.utilities.DummyTextAnnotationGenerator;
 import edu.illinois.cs.cogcomp.core.utilities.SerializationHelper;
 import junit.framework.TestCase;
 import org.junit.Before;
@@ -66,4 +69,12 @@ public class TextAnnotationSerializationTest {
         assertEquals(ta2.getText(), ta.getText());
     }
 
+    @Test
+    public void testPredicateArgumentSerialization() throws Exception {
+        TextAnnotation ta = DummyTextAnnotationGenerator.generateAnnotatedTextAnnotation(false, 3);
+        String json = SerializationHelper.serializeToJson(ta);
+        TextAnnotation ta2 = SerializationHelper.deserializeFromJson(json);
+        assertEquals(((PredicateArgumentView)ta.getView(ViewNames.SRL_VERB)).getPredicates().size(),
+                ((PredicateArgumentView)ta2.getView(ViewNames.SRL_VERB)).getPredicates().size());
+    }
 }

--- a/prepsrl/src/main/java/edu/illinois/cs/cogcomp/prepsrl/PrepSRLAnnotator.java
+++ b/prepsrl/src/main/java/edu/illinois/cs/cogcomp/prepsrl/PrepSRLAnnotator.java
@@ -9,11 +9,9 @@ package edu.illinois.cs.cogcomp.prepsrl;
 
 import edu.illinois.cs.cogcomp.annotation.Annotator;
 import edu.illinois.cs.cogcomp.annotation.AnnotatorException;
+import edu.illinois.cs.cogcomp.core.datastructures.IQueryable;
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
-import edu.illinois.cs.cogcomp.core.datastructures.textannotation.Constituent;
-import edu.illinois.cs.cogcomp.core.datastructures.textannotation.SpanLabelView;
-import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
-import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TokenLabelView;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.*;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.depparse.DepConfigurator;
 import edu.illinois.cs.cogcomp.lbjava.classify.Classifier;
@@ -21,8 +19,7 @@ import edu.illinois.cs.cogcomp.lbjava.nlp.DataReader;
 import edu.illinois.cs.cogcomp.prepsrl.data.PrepSRLDataReader;
 import edu.illinois.cs.cogcomp.prepsrl.inference.ConstrainedPrepSRLClassifier;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 /**
  * An {@link Annotator} that adds a {@link TokenLabelView} for Prepositional SRL. This consists of
@@ -81,12 +78,45 @@ public class PrepSRLAnnotator extends Annotator {
                 candidates.add(multiWordPrep);
         }
 
-        SpanLabelView prepositionLabelView = new SpanLabelView(viewName, viewName + "-annotator", ta, 1.0, true);
+        PredicateArgumentView prepositionLabelView = new PredicateArgumentView(viewName, viewName + "-annotator", ta, 1.0);
+
+
+        IQueryable<Constituent> chunkCons = ta.select(ViewNames.SHALLOW_PARSE);
         for (Constituent c : candidates) {
             String role = classifier.discreteValue(c);
-            if (!role.equals(DataReader.CANDIDATE))
-                prepositionLabelView.addSpanLabel(c.getStartSpan(), c.getEndSpan(), role, 1.0);
+            if (!role.equals(DataReader.CANDIDATE)) {
+                Constituent p = new Constituent(role, 1.0, viewName, ta, c.getStartSpan(), c.getEndSpan());
+
+                List<String> relations = new ArrayList<>();
+                List<Constituent> arguments = new ArrayList<>();
+
+                // adding source and target constituents from chunk view
+                IQueryable<Constituent> before = chunkCons.where(Queries.before(c));
+                before.orderBy((o1, o2) -> {
+                    // Descending order to find the nearest before
+                    return o2.getEndSpan() - o1.getEndSpan();
+                });
+                Iterator<Constituent> beforeIt = before.iterator();
+                if (beforeIt.hasNext()) {
+                    Constituent nearestBefore = beforeIt.next();
+                    arguments.add(nearestBefore);
+                    relations.add("before");
+                }
+
+                IQueryable<Constituent> after = chunkCons.where(Queries.after(c));
+                after.orderBy(Comparator.comparingInt(Constituent::getEndSpan));
+                Iterator<Constituent> afterIt = after.iterator();
+                if (afterIt.hasNext()) {
+                    Constituent nearestAfter = afterIt.next();
+                    arguments.add(nearestAfter);
+                    relations.add("after");
+                }
+                double[] scores = new double[arguments.size()];
+                Arrays.fill(scores, 1.0);
+                prepositionLabelView.addPredicateArguments(p, arguments, relations.toArray(new String[relations.size()]), scores);
+            }
         }
+
         ta.addView(viewName, prepositionLabelView);
     }
 }

--- a/prepsrl/src/test/java/edu/illinois/cs/cogcomp/prepsrl/PrepSRLAnnotatorTest.java
+++ b/prepsrl/src/test/java/edu/illinois/cs/cogcomp/prepsrl/PrepSRLAnnotatorTest.java
@@ -8,6 +8,7 @@
 package edu.illinois.cs.cogcomp.prepsrl;
 
 import edu.illinois.cs.cogcomp.annotation.Annotator;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.PredicateArgumentView;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotationUtilities;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
@@ -32,7 +33,7 @@ public class PrepSRLAnnotatorTest {
     public void testDummy() throws Exception {
         TextAnnotation ta = DummyTextAnnotationGenerator.generateAnnotatedTextAnnotation(false, 1);
         View view = annotator.getView(ta);
-        assertEquals("ObjectOfVerb", view.getConstituents().get(0).getLabel());
+        assertEquals("ObjectOfVerb", ((PredicateArgumentView)view).getPredicates().get(0).getLabel());
     }
 
     @Test
@@ -41,7 +42,7 @@ public class PrepSRLAnnotatorTest {
         TextAnnotation ta = TextAnnotationUtilities.createFromTokenizedString(shortSentence);
         preprocessor.annotate(ta);
         View view = annotator.getView(ta);
-        assertEquals("Location", view.getConstituents().get(0).getLabel());
+        assertEquals("Location", ((PredicateArgumentView)view).getPredicates().get(0).getLabel());
     }
 
     @Test
@@ -52,8 +53,9 @@ public class PrepSRLAnnotatorTest {
                         + "traceable to a single defective gene .";
         TextAnnotation ta = TextAnnotationUtilities.createFromTokenizedString(longSentence);
         preprocessor.annotate(ta);
-        View view = annotator.getView(ta);
-        assertEquals("Source", view.getConstituents().get(0).getLabel());
+        PredicateArgumentView view = (PredicateArgumentView)annotator.getView(ta);
+        assertEquals("Source", view.getPredicates().get(0).getLabel());
+        System.out.println(view);
     }
 
     @Test
@@ -64,6 +66,6 @@ public class PrepSRLAnnotatorTest {
         TextAnnotation ta = TextAnnotationUtilities.createFromTokenizedString(longSentence);
         preprocessor.annotate(ta);
         View view = annotator.getView(ta);
-        assertEquals("ahead of", view.getConstituents().get(0).getSurfaceForm());
+        assertEquals("ahead of", ((PredicateArgumentView)view).getPredicates().get(0).getSurfaceForm());
     }
 }


### PR DESCRIPTION
Changes prep-srl view to PredicateArgumentView and adds before-after phrases as arguments of each preposition. 

Here is a sample output: 
```
into:
    after: an afflicted individual
    before: genes
for:
    after: therapeutic purposes
    before: an afflicted individual
for:
    after: treating
    before: great potential
of:
    after: disorders
    before: the relatively small number
to:
    after: a single defective gene
    before: traceable

```