### PR TITLE
Updated CoNLLNerReader to suppport unitary labels (U-XXX)

### DIFF
--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/CoNLLNerReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/CoNLLNerReader.java
@@ -178,7 +178,7 @@ public class CoNLLNerReader extends AnnotationReader<TextAnnotation> {
             String[] sline = line.split("\t");
 
 
-            if (line.startsWith("B-")) {
+            if (line.startsWith("B-") || line.startsWith("U-")) {
                 // two consecutive entities.
                 if (start > -1) {
                     // peel off a constituent if it exists.

--- a/corpusreaders/src/test/resources/conlldocs/test2.conll
+++ b/corpusreaders/src/test/resources/conlldocs/test2.conll
@@ -8,7 +8,7 @@ O	0	6	x	,	,	x	x	0
 B-PER	0	7	x	NNP	Wayne	x	x	0
 I-PER	0	8	x	NNP	Riley	x	x	0
 O	0	9	x	(	(	x	x	0
-B-LOC	0	10	x	NNP	Australia	x	x	0
+U-LOC	0	10	x	NNP	Australia	x	x	0
 O	0	11	x	)	)	x	x	0
 O	0	12	x	CD	71	x	x	0
 O	0	13	x	CD	78	x	x	0
@@ -35,7 +35,7 @@ O	0	14	x	,	,	x	x	0
 B-PER	0	0	x	NNP	Peter	x	x	0
 I-PER	0	1	x	NNP	Hedblom	x	x	0
 O	0	2	x	(	(	x	x	0
-B-LOC	0	3	x	NNP	Sweden	x	x	0
+U-LOC	0	3	x	NNP	Sweden	x	x	0
 O	0	4	x	)	)	x	x	0
 O	0	5	x	CD	70	x	x	0
 O	0	6	x	CD	75	x	x	0
@@ -62,11 +62,11 @@ O	0	0	x	-X-	-DOCSTART-	x	x	0
 
 O	0	0	x	NN	SOCCER	x	x	0
 O	0	1	x	:	-	x	x	0
-B-MISC	0	2	x	JJ	ENGLISH	x	x	0
+U-MISC	0	2	x	JJ	ENGLISH	x	x	0
 O	0	3	x	NNP	SOCCER	x	x	0
 O	0	4	x	NNS	RESULTS	x	x	0
 O	0	5	x	.	.	x	x	0
 O	0	5	x	.		x	x	0
 
-B-LOC	0	0	x	NNP	LONDON	x	x	0
+U-LOC	0	0	x	NNP	LONDON	x	x	0
 O	0	1	x	CD	1996-08-30	x	x	0


### PR DESCRIPTION
A simple fix to support unitary labels such as "U-LOC" in `CoNLLNerReader`, as unitary labels are supported in `CoNLL2002Writer`. Minor modifications to one of the unit test files to test the new behavior.