### PR TITLE
fix tokenizer dot issue

### DIFF
--- a/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/TokenizerStateMachine.java
+++ b/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/TokenizerStateMachine.java
@@ -299,7 +299,7 @@ public class TokenizerStateMachine {
                                             // punctuation then, pass through
                                         }
                                     } else {
-                                        if ( (Character.isAlphabetic(c) && !Character.isUpperCase(c)) || Character.isDigit(c))
+                                        if ( (Character.isAlphabetic(c) && Character.isUpperCase(c)) || Character.isDigit(c))
                                             // the next character is not white space, so the period
                                             // is part of the word
                                             return;


### PR DESCRIPTION
This line fixes the logic where the tokenizer stops in the middle of a word. 

Take "U.S." as an example, when the old version of tokenizer meets the first ".", it will check the next character which is "S". "S" is an alphabet but it is an uppercase character,  which causes the process() fails to return and thus causing the current word to end at the first dot, which it is not supposed to.

