### PR TITLE
fix path-lstm.

### DIFF
--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/View.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/View.java
@@ -416,7 +416,6 @@ public class View implements Serializable, IQueryable<Constituent> {
     public List<Constituent> getConstituentsWithSpan(IntPair span) {
         List<Constituent> list = new ArrayList<>();
         for(Constituent c : this.constituents) if (c.getSpan().equals(span)) list.add(c);
-        list.sort(TextAnnotationUtilities.constituentStartComparator);
         return list;
     }
 

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/View.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/View.java
@@ -8,6 +8,7 @@
 package edu.illinois.cs.cogcomp.core.datastructures.textannotation;
 
 import edu.illinois.cs.cogcomp.core.datastructures.IQueryable;
+import edu.illinois.cs.cogcomp.core.datastructures.IntPair;
 import edu.illinois.cs.cogcomp.core.datastructures.QueryableList;
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.transformers.ITransformer;
@@ -409,6 +410,16 @@ public class View implements Serializable, IQueryable<Constituent> {
         return list;
     }
 
+    /**
+     * @return all the constituents that have exact span start/end.
+     */
+    public List<Constituent> getConstituentsWithSpan(IntPair span) {
+        List<Constituent> list = new ArrayList<>();
+        for(Constituent c : this.constituents) if (c.getSpan().equals(span)) list.add(c);
+        list.sort(TextAnnotationUtilities.constituentStartComparator);
+        return list;
+    }
+
     public List<Constituent> getConstituentsCoveringTokens(Collection<Integer> tokenIds) {
 
         Set<Constituent> output = new HashSet<>();
@@ -591,5 +602,4 @@ public class View implements Serializable, IQueryable<Constituent> {
     public int count() {
         return this.constituents.size();
     }
-
 }

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/utilities/JsonSerializer.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/utilities/JsonSerializer.java
@@ -102,6 +102,14 @@ public class JsonSerializer extends AbstractSerializer {
 
         if (relations.size() > 0) {
 
+            // if we're using relations, constituents shouldn't have any duplicates; otherwise upon deserialization
+            // things would not be as expected
+            Set<Constituent> consSet = new HashSet<>(constituents);
+            if(consSet.size() < constituents.size())
+                logger.error("There are duplicate constituents in the '" + view + "' view. " +
+                        "You have to fix this otherwise things will be messed up, upon deserialization. ");
+
+
             JsonArray rJson = new JsonArray();
 
             for (Relation r : relations) {

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/utilities/JsonSerializer.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/utilities/JsonSerializer.java
@@ -88,7 +88,6 @@ public class JsonSerializer extends AbstractSerializer {
         if (constituents.size() > 0) {
             JsonArray cJson = new JsonArray();
             for (int i = 0; i < view.getNumberOfConstituents(); i++) {
-
                 Constituent constituent = constituents.get(i);
                 JsonObject c = new JsonObject();
                 writeConstituent(constituent, c);
@@ -184,8 +183,7 @@ public class JsonSerializer extends AbstractSerializer {
                 int tgt = readInt("targetConstituent", rJ);
 
                 Map<String, Double> labelsToScores = null;
-                if (rJ.has(LABEL_SCORE_MAP))
-                {
+                if (rJ.has(LABEL_SCORE_MAP)) {
                     labelsToScores = new HashMap<>();
                     readLabelsToScores(labelsToScores, rJ);
                 }
@@ -470,7 +468,6 @@ public class JsonSerializer extends AbstractSerializer {
 
             for (int k = 0; k < viewData.size(); k++) {
                 JsonObject kView = (JsonObject) viewData.get(k);
-
                 topKViews.add(readView(kView, ta));
             }
 

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/utilities/SerializationHelper.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/utilities/SerializationHelper.java
@@ -40,14 +40,14 @@ public class SerializationHelper {
         serializeTextAnnotationToFile(ta, fileName, forceOverwrite, false);
     }
 
-        /**
-         * Serialize a TextAnnotation and then write to file. If forceOverwrite_ is set to false and
-         * file already exists, this method throws an exception.
-         *
-         * @param ta The text annotation to be serialized
-         * @param fileName Name of file to write to
-         * @param forceOverwrite Whether or not to overwrite existing file.
-         */
+    /**
+     * Serialize a TextAnnotation and then write to file. If forceOverwrite_ is set to false and
+     * file already exists, this method throws an exception.
+     *
+     * @param ta The text annotation to be serialized
+     * @param fileName Name of file to write to
+     * @param forceOverwrite Whether or not to overwrite existing file.
+     */
     public static void serializeTextAnnotationToFile(TextAnnotation ta, String fileName,
             boolean forceOverwrite, boolean useJson) throws IOException {
         File outFile = new File(fileName);
@@ -67,7 +67,6 @@ public class SerializationHelper {
         }
     }
 
-
     /**
      * Serialize a text annotation into a byte array. This can be useful for writing into a file or
      * a database record. Uses Apache's {@link SerializationUtils}.
@@ -78,7 +77,6 @@ public class SerializationHelper {
     public static byte[] serializeTextAnnotationToBytes(TextAnnotation ta) throws IOException {
         return SerializationUtils.serialize(ta);
     }
-
 
     /**
      * Read serialized record from file and deserialize it. Expects Thrift serialization format, one
@@ -91,8 +89,6 @@ public class SerializationHelper {
             throws Exception {
         return deserializeTextAnnotationFromFile(fileName, false);
     }
-
-
 
     /**
          * Read serialized record from file and deserialize it. Expects Thrift serialization format, one
@@ -163,7 +159,6 @@ public class SerializationHelper {
      * @throws Exception
      */
     public static TextAnnotation deserializeFromJson(String jsonString) throws Exception {
-
         JsonSerializer serializer = new JsonSerializer();
         return serializer.readTextAnnotation(jsonString);
     }

--- a/external/src/main/java/edu/illinois/cs/cogcomp/pipeline/handlers/PathLSTMHandler.java
+++ b/external/src/main/java/edu/illinois/cs/cogcomp/pipeline/handlers/PathLSTMHandler.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -117,7 +116,9 @@ public class PathLSTMHandler extends Annotator {
                     IntPair span = new IntPair(y.first().getIdx() - 1, y.last().getIdx());
                     Constituent c = new Constituent("Argument", viewName, ta, span.getFirst(), span.getSecond());
                     assert span.getFirst() <= span.getSecond(): ta;
-                    if(!pav.getConstituents().contains(c)) pav.addConstituent(c);
+                    List<Constituent> consList = pav.getConstituentsWithSpan(new IntPair(span.getFirst(),
+                            span.getSecond()));
+                    if(consList.isEmpty()) pav.addConstituent(c);
                     pav.addRelation(new Relation(label, predicate, c, 1.0));
                 }
             }

--- a/external/src/main/java/edu/illinois/cs/cogcomp/pipeline/handlers/PathLSTMHandler.java
+++ b/external/src/main/java/edu/illinois/cs/cogcomp/pipeline/handlers/PathLSTMHandler.java
@@ -117,20 +117,20 @@ public class PathLSTMHandler extends Annotator {
                 List<String> relations = new ArrayList<>();
 
                 for (Word a : p.getArgMap().keySet()) {
-
                     Set<Word> singleton = new TreeSet<Word>();
                     String label = p.getArgumentTag(a);
                     Yield y = a.getYield(p, label, singleton);
                     IntPair span = new IntPair(y.first().getIdx() - 1, y.last().getIdx());
 
                     assert span.getFirst() <= span.getSecond() : ta;
-                    args.add(new Constituent(label, viewName, ta, span.getFirst(), span.getSecond()));
+                    if(pav.getConstituentsCoveringSpan(span.getFirst(), span.getSecond()).size() == 0)
+                        args.add(new Constituent("Argument", viewName, ta, span.getFirst(), span.getSecond()));
+                    else
+                        args.add(pav.getConstituentsCoveringSpan(span.getFirst(), span.getSecond()).get(0));
                     relations.add(label);
                 }
-
                 pav.addPredicateArguments(predicate, args,
                         relations.toArray(new String[relations.size()]), new double[relations.size()]);
-
             }
         }
 


### PR DESCRIPTION
When there are redundant constituents in the predicate-argument view, things get messed up upon serialization-deserialization (and it's not noticed until you actually do deserialize it). 

I changed path-lstm handler so that we don't add redundant constituents. 
