### PR TITLE
fix ereReader's head reading

### DIFF
--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/ERENerReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/ERENerReader.java
@@ -620,7 +620,7 @@ public class ERENerReader extends EREDocumentReader {
         if (mnl.getLength() > 0) {
 
             Node headNode = mnl.item(0);
-            nnMap = mentionNode.getAttributes();
+            nnMap = headNode.getAttributes();
             headForm = headNode.getNodeValue();
             int headStart = Integer.parseInt(nnMap.getNamedItem(OFFSET).getNodeValue());
             int headLength = Integer.parseInt(nnMap.getNamedItem(LENGTH).getNodeValue());


### PR DESCRIPTION
Previously there is an error which causes failures of reading mention heads. I tested through experiments and before this fix, all mentions heads are the same as mentions themselves. This fix seems to solve the issue, tested by experiments.