### PR TITLE
Small additions to external annotators 

### DIFF
--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/AnnotatorServiceConfigurator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/AnnotatorServiceConfigurator.java
@@ -19,7 +19,6 @@ import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
  * @since 9/11/15
  */
 public class AnnotatorServiceConfigurator extends Configurator {
-
     public static final Property CACHE_DIR = new Property("cacheDirectory", "annotation-cache");
     public static final Property THROW_EXCEPTION_IF_NOT_CACHED = new Property(
             "throwExceptionIfNotCached", Configurator.FALSE);

--- a/curator/src/main/java/edu/illinois/cs/cogcomp/curator/CuratorAnnotatorService.java
+++ b/curator/src/main/java/edu/illinois/cs/cogcomp/curator/CuratorAnnotatorService.java
@@ -127,6 +127,10 @@ public class CuratorAnnotatorService implements AnnotatorService {
             viewProviders.put(annotator.getViewName(), annotator);
     }
 
+    public void setCacheName(String newName) {
+        this.cacheFile = newName;
+    }
+
     @Override
     public TextAnnotation createBasicTextAnnotation(String corpusId, String docId, String text)
             throws AnnotatorException {

--- a/external/clausie/src/main/java/edu/illinois/cs/cogcomp/pipeline/ClausIE_AnnotatorService.java
+++ b/external/clausie/src/main/java/edu/illinois/cs/cogcomp/pipeline/ClausIE_AnnotatorService.java
@@ -26,6 +26,7 @@ public class ClausIE_AnnotatorService {
         Map<String, Annotator> viewGenerators = new HashMap<>();
         ClausIEAnnotator annotator = new ClausIEAnnotator();
         viewGenerators.put(annotator.getViewName(), annotator);
-        service = ExternalAnnotatorServiceFactory.buildPipeline(viewGenerators);
+        service = ExternalAnnotatorServiceFactory.buildPipeline(viewGenerators,
+                ClausIE_AnnotatorService.class.getSimpleName());
     }
 }

--- a/external/external-commons/src/main/java/edu/illinois/cs/cogcomp/pipeline/main/ExternalAnnotatorServiceFactory.java
+++ b/external/external-commons/src/main/java/edu/illinois/cs/cogcomp/pipeline/main/ExternalAnnotatorServiceFactory.java
@@ -29,8 +29,10 @@ public class ExternalAnnotatorServiceFactory {
      * @throws IOException
      * @throws AnnotatorException
      */
-    public static BasicAnnotatorService buildPipeline(Map<String, Annotator> annotators) throws IOException, AnnotatorException {
-        ResourceManager emptyConfig = new ResourceManager(new Properties());
+    public static BasicAnnotatorService buildPipeline(Map<String, Annotator> annotators, String cacheName) throws IOException, AnnotatorException {
+        Properties p = new Properties();
+        p.setProperty(AnnotatorServiceConfigurator.CACHE_DIR.key, cacheName);
+        ResourceManager emptyConfig = new ResourceManager(p);
         return buildPipeline(emptyConfig, annotators);
     }
 

--- a/external/external-commons/src/main/java/edu/illinois/cs/cogcomp/pipeline/main/ExternalAnnotatorServiceFactory.java
+++ b/external/external-commons/src/main/java/edu/illinois/cs/cogcomp/pipeline/main/ExternalAnnotatorServiceFactory.java
@@ -29,9 +29,9 @@ public class ExternalAnnotatorServiceFactory {
      * @throws IOException
      * @throws AnnotatorException
      */
-    public static BasicAnnotatorService buildPipeline(Map<String, Annotator> annotators, String cacheName) throws IOException, AnnotatorException {
+    public static BasicAnnotatorService buildPipeline(Map<String, Annotator> annotators, String cacheDirectory) throws IOException, AnnotatorException {
         Properties p = new Properties();
-        p.setProperty(AnnotatorServiceConfigurator.CACHE_DIR.key, cacheName);
+        p.setProperty(AnnotatorServiceConfigurator.CACHE_DIR.key, cacheDirectory);
         ResourceManager emptyConfig = new ResourceManager(p);
         return buildPipeline(emptyConfig, annotators);
     }

--- a/external/listEmptyPorts.py
+++ b/external/listEmptyPorts.py
@@ -12,7 +12,6 @@ from subprocess import check_output
 
 # list of potential port addresses
 ports = [8080, 8443, 1503, 1720, 1731, 3283, 5988, 8009]
-modules = ["clausie", "path-lstm", "stanford_3.8.0"]
 
 def checkPortAvailability(port):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/external/path-lstm/src/main/java/edu/illinois/cs/cogcomp/pipeline/PathLSTM_AnnotatorService.java
+++ b/external/path-lstm/src/main/java/edu/illinois/cs/cogcomp/pipeline/PathLSTM_AnnotatorService.java
@@ -26,6 +26,7 @@ public class PathLSTM_AnnotatorService {
         Map<String, Annotator> viewGenerators = new HashMap<>();
         PathLSTMHandler pathSRL = new PathLSTMHandler(true);
         viewGenerators.put(pathSRL.getViewName(), pathSRL);
-        service = ExternalAnnotatorServiceFactory.buildPipeline(viewGenerators);
+        service = ExternalAnnotatorServiceFactory.buildPipeline(viewGenerators,
+                PathLSTM_AnnotatorService.class.getSimpleName());
     }
 }

--- a/external/path-lstm/src/main/java/edu/illinois/cs/cogcomp/pipeline/handlers/PathLSTMHandler.java
+++ b/external/path-lstm/src/main/java/edu/illinois/cs/cogcomp/pipeline/handlers/PathLSTMHandler.java
@@ -129,12 +129,13 @@ public class PathLSTMHandler extends Annotator {
                             predicate.addAttribute(PredicateArgumentView.SenseIdentifer, senseOnly);
                             FrameData.SenseFrameData frameData = null;
                             if(p.getPOS().startsWith("N")) {
-                                frameData = propBankManager.getFrameWithSense(predicateLemma, senseOnly);
-                            }
-                            else {
+                                // if it's noun, load from NomBank
                                 frameData = nomBankManager.getFrameWithSense(predicateLemma, senseOnly);
                             }
-
+                            else {
+                                // otherwise, use propbank
+                                frameData = propBankManager.getFrameWithSense(predicateLemma, senseOnly);
+                            }
                             pav.addConstituent(predicate);
 
                             for (Word a : p.getArgMap().keySet()) {

--- a/external/runAllExternalAnnotators.py
+++ b/external/runAllExternalAnnotators.py
@@ -1,6 +1,7 @@
 ####
 # A simple script to run all the servers of the external annotators on different ports.
 # it first selects a bunch of open ports, and then tries running the modules on the free ports
+# designed for Python 2.7
 ####
 
 from __future__ import print_function
@@ -8,7 +9,6 @@ import os
 import sys
 import socket
 from subprocess import check_output
-from subprocess import run
 
 # list of potential port addresses
 ports = [8080, 8443, 1503, 1720, 1731, 3283, 5988, 8009]
@@ -36,7 +36,7 @@ def main():
     for index, elem in enumerate(modules):
         port = filteredPorts[index]
         print("running module `" + elem + "` on port `" + port + "`")
-        run([elem + "/scripts/runWebserver.sh", "-p", port])
+        check_output([elem + "/scripts/runWebserver.sh", "-p", port])
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/external/runAllExternalAnnotators.py
+++ b/external/runAllExternalAnnotators.py
@@ -1,11 +1,11 @@
 ####
-# A simple script to run all the servers of the external annotators on different ports.
-# it first selects a bunch of open ports, and then tries running the modules on the free ports
-# designed for Python 2.7
+# A simple script to list the available ports on the current server
+# designed to work for Python 3.5
 ####
 
 from __future__ import print_function
 import os
+import re
 import sys
 import socket
 from subprocess import check_output
@@ -25,18 +25,14 @@ def checkPortAvailability(port):
 
 # full command in linux: netstat -lnt | awk '$6 == "LISTEN" && $4 ~ ".445"'
 def getUsedPorts():
-    output = check_output(["netstat", "-lnt"])
-    items_split = [ re.sub(' +',' ', i).split(' ') for i in output.split('\n')]
-    return set([x[3].split(":")[-1] for x in items_split if len(x) == 7 and x[5] == 'LISTEN'])
+    output = str(check_output(["netstat", "-lnt"]))
+    items_split = [ re.sub(' +',' ', i).split(' ') for i in output.split('\\n')]
+    return [int(x[3].split(":")[-1]) for x in items_split if len(x) == 7 and x[5] == 'LISTEN']
 
 def main():
     portsUsed = getUsedPorts()
-    filteredPorts = [p for p in ports if p in portsUsed]
-    assert len(modules) <= len(filteredPorts), "there are less number of open ports to be used for modules"
-    for index, elem in enumerate(modules):
-        port = filteredPorts[index]
-        print("running module `" + elem + "` on port `" + port + "`")
-        check_output([elem + "/scripts/runWebserver.sh", "-p", port])
+    filteredPorts = [p for p in ports if p not in portsUsed]
+    print("list of open ports: " + str(filteredPorts))
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/external/runAllExternalAnnotators.py
+++ b/external/runAllExternalAnnotators.py
@@ -1,0 +1,42 @@
+####
+# A simple script to run all the servers of the external annotators on different ports.
+# it first selects a bunch of open ports, and then tries running the modules on the free ports
+####
+
+from __future__ import print_function
+import os
+import sys
+import socket
+from subprocess import check_output
+from subprocess import run
+
+# list of potential port addresses
+ports = [8080, 8443, 1503, 1720, 1731, 3283, 5988, 8009]
+modules = ["clausie", "path-lstm", "stanford_3.8.0"]
+
+def checkPortAvailability(port):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    result = sock.connect_ex(('127.0.0.1', port))
+    print("Post `" + str(port) + "` availability: `" + str(result) + "`")
+    if result == 0:
+        return True
+    else:
+        return False
+
+# full command in linux: netstat -lnt | awk '$6 == "LISTEN" && $4 ~ ".445"'
+def getUsedPorts():
+    output = check_output(["netstat", "-lnt"])
+    items_split = [ re.sub(' +',' ', i).split(' ') for i in output.split('\n')]
+    return set([x[3].split(":")[-1] for x in items_split if len(x) == 7 and x[5] == 'LISTEN'])
+
+def main():
+    portsUsed = getUsedPorts()
+    filteredPorts = [p for p in ports if p in portsUsed]
+    assert len(modules) <= len(filteredPorts), "there are less number of open ports to be used for modules"
+    for index, elem in enumerate(modules):
+        port = filteredPorts[index]
+        print("running module `" + elem + "` on port `" + port + "`")
+        run([elem + "/scripts/runWebserver.sh", "-p", port])
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/external/stanford_3.8.0/src/main/java/edu/illinois/cs/cogcomp/pipeline/Stanford_3_8_0_AnnotatorService.java
+++ b/external/stanford_3.8.0/src/main/java/edu/illinois/cs/cogcomp/pipeline/Stanford_3_8_0_AnnotatorService.java
@@ -37,6 +37,7 @@ public class Stanford_3_8_0_AnnotatorService {
         StanfordTrueCaseHandler trueCaseHandler = new StanfordTrueCaseHandler();
         viewGenerators.put(trueCaseHandler.getViewName(), trueCaseHandler);
 
-        service = ExternalAnnotatorServiceFactory.buildPipeline(viewGenerators);
+        service = ExternalAnnotatorServiceFactory.buildPipeline(viewGenerators,
+                Stanford_3_8_0_AnnotatorService.class.getSimpleName());
     }
 }


### PR DESCRIPTION
Changes: 
- Often times one of my struggles is to figure out what port is available to run an annotation server.
This scripts automates this process.
- fix a bug in path-lstm: has to switch NomBank and PropBank
- add annotator-specific cache names, so that they don't conflict 


