### PR TITLE
Mention Detection fixes

### DIFF
--- a/md/README.md
+++ b/md/README.md
@@ -59,6 +59,8 @@ The mode parameter has four options:
 
 The initialization of `MentionAnnotator()` without parameter set mode to `"ACE_NONTYPE"`
 
+There is a static function `getHeadConstituent(Constituent extent, String viewName)` built into the annotator. It can be used to get a constituent that is only the head, with all the attributes that the extent constituent has.
+
 
 ```java
 import edu.illinois.cs.cogcomp.annotation.AnnotatorException;
@@ -98,6 +100,10 @@ public class app
 
         View mentionView = ta.getView(ViewNames.MENTION);
         List<Constituent> predictedMentions = mentionView.getConstituents();
+        for (Constituent extent : predictedMentions){
+            //Get the head if needed
+            Constituent head = MentionAnnotator.getHeadConstituent(extent, "MENTION_HEAD");
+        }
     }
 }
 ```

--- a/md/README.md
+++ b/md/README.md
@@ -59,7 +59,7 @@ The mode parameter has four options:
 
 The initialization of `MentionAnnotator()` without parameter set mode to `"ACE_NONTYPE"`
 
-There is a static function `getHeadConstituent(Constituent extent, String viewName)` built into the annotator. It can be used to get a constituent that is only the head, with all the attributes that the extent constituent has.
+There is a static function `getHeadConstituent(Constituent extent, String viewName)` built into the annotator, which returns the mention-heads.
 
 
 ```java

--- a/md/pom.xml
+++ b/md/pom.xml
@@ -58,6 +58,11 @@
             <version>1.7.12</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.7</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/md/src/main/java/org/cogcomp/md/BIOTester.java
+++ b/md/src/main/java/org/cogcomp/md/BIOTester.java
@@ -306,7 +306,7 @@ public class BIOTester {
         }
         int startIdx = curToken.getStartSpan();
         int endIdx = startIdx + 1;
-        if (endIdx < bioView.getEndSpan()) {
+        if (inference(curToken, classifier).startsWith("B") && endIdx < bioView.getEndSpan()) {
             String preBIOLevel2_dup = curToken.getAttribute("preBIOLevel1");
             String preBIOLevel1_dup = inference(curToken, classifier);
             Constituent pointerToken = null;
@@ -336,9 +336,13 @@ public class BIOTester {
         Constituent wholeMention = new Constituent(curToken.getLabel(), 1.0f, "BIO_Mention", curToken.getTextAnnotation(), startIdx, endIdx);
         if (isGold){
             wholeMention.addAttribute("EntityType", goldType);
+            wholeMention.addAttribute("EntityMentionType", curToken.getAttribute("EntityMentionType"));
         }
         else{
             wholeMention.addAttribute("EntityType", mostCommon(predictedTypes));
+            String className = classifier.getClass().toString();
+            String emt = className.substring(className.length() - 3).toUpperCase();
+            wholeMention.addAttribute("EntityMentionType", emt);
         }
         return wholeMention;
     }

--- a/md/src/main/java/org/cogcomp/md/BIOTester.java
+++ b/md/src/main/java/org/cogcomp/md/BIOTester.java
@@ -306,6 +306,8 @@ public class BIOTester {
         }
         int startIdx = curToken.getStartSpan();
         int endIdx = startIdx + 1;
+        //Continue to check if the predicted mentions continues to the right
+        //if and only if the start predicted BIOLU tag is "B"
         if (inference(curToken, classifier).startsWith("B") && endIdx < bioView.getEndSpan()) {
             String preBIOLevel2_dup = curToken.getAttribute("preBIOLevel1");
             String preBIOLevel1_dup = inference(curToken, classifier);
@@ -341,6 +343,8 @@ public class BIOTester {
         else{
             wholeMention.addAttribute("EntityType", mostCommon(predictedTypes));
             String className = classifier.getClass().toString();
+            //The className variable is in form "...bio_classifier_[TYPE]"
+            //Take the last three characters which stands for the mention level.
             String emt = className.substring(className.length() - 3).toUpperCase();
             wholeMention.addAttribute("EntityMentionType", emt);
         }

--- a/md/src/main/java/org/cogcomp/md/MentionAnnotator.java
+++ b/md/src/main/java/org/cogcomp/md/MentionAnnotator.java
@@ -212,4 +212,22 @@ public class MentionAnnotator extends Annotator{
         ta.addView(ViewNames.MENTION, mentionView);
     }
 
+    /**
+     *
+     * @param c The input full extent constituent
+     * @param viewName The expected view name that you want the head constituent to have
+     * @return A constituent that is only the head
+     */
+    public static Constituent getHeadConstituent(Constituent c, String viewName){
+        if (c.getAttribute("EntityHeadStartSpan") == null || c.getAttribute("EntityHeadEndSpan") == null){
+            return null;
+        }
+        int cStart = Integer.parseInt(c.getAttribute("EntityHeadStartSpan"));
+        int cEnd = Integer.parseInt(c.getAttribute("EntityHeadEndSpan"));
+        Constituent ret = new Constituent(c.getLabel(), viewName, c.getTextAnnotation(), cStart, cEnd);
+        for (String attributeKey : c.getAttributeKeys()) {
+            ret.addAttribute(attributeKey, c.getAttribute(attributeKey));
+        }
+        return ret;
+    }
 }

--- a/md/src/main/java/org/cogcomp/md/MentionAnnotator.java
+++ b/md/src/main/java/org/cogcomp/md/MentionAnnotator.java
@@ -48,7 +48,6 @@ public class MentionAnnotator extends Annotator{
     private FlatGazetteers gazetteers;
     private BrownClusters brownClusters;
     private WordNetManager wordNet;
-    private POSAnnotator posAnnotator;
 
     private String _mode;
     /**
@@ -73,7 +72,6 @@ public class MentionAnnotator extends Annotator{
     public MentionAnnotator(boolean lazilyInitialize, String mode){
         super(ViewNames.MENTION, new String[]{ViewNames.POS}, lazilyInitialize);
         _mode = mode;
-        posAnnotator = new POSAnnotator();
     }
 
     public void initialize(ResourceManager rm){
@@ -162,7 +160,7 @@ public class MentionAnnotator extends Annotator{
             doInitialize();
         }
         if (!ta.hasView(ViewNames.POS)){
-            ta.addView(posAnnotator);
+            throw new AnnotatorException("Missing required view POS");
         }
         View mentionView = new SpanLabelView(ViewNames.MENTION, MentionAnnotator.class.getCanonicalName(), ta, 1.0f, true);
         View bioView = new SpanLabelView("BIO", BIOReader.class.getCanonicalName(), ta, 1.0f);

--- a/md/src/main/java/org/cogcomp/md/MentionAnnotator.java
+++ b/md/src/main/java/org/cogcomp/md/MentionAnnotator.java
@@ -7,6 +7,7 @@
  */
 package org.cogcomp.md;
 
+import edu.illinois.cs.cogcomp.pos.POSAnnotator;
 import org.cogcomp.md.LbjGen.*;
 
 import edu.illinois.cs.cogcomp.annotation.Annotator;
@@ -47,6 +48,7 @@ public class MentionAnnotator extends Annotator{
     private FlatGazetteers gazetteers;
     private BrownClusters brownClusters;
     private WordNetManager wordNet;
+    private POSAnnotator posAnnotator;
 
     private String _mode;
     /**
@@ -71,6 +73,7 @@ public class MentionAnnotator extends Annotator{
     public MentionAnnotator(boolean lazilyInitialize, String mode){
         super(ViewNames.MENTION, new String[]{ViewNames.POS}, lazilyInitialize);
         _mode = mode;
+        posAnnotator = new POSAnnotator();
     }
 
     public void initialize(ResourceManager rm){
@@ -157,6 +160,9 @@ public class MentionAnnotator extends Annotator{
     public void addView(TextAnnotation ta) throws AnnotatorException{
         if (!isInitialized()){
             doInitialize();
+        }
+        if (!ta.hasView(ViewNames.POS)){
+            ta.addView(posAnnotator);
         }
         View mentionView = new SpanLabelView(ViewNames.MENTION, MentionAnnotator.class.getCanonicalName(), ta, 1.0f, true);
         View bioView = new SpanLabelView("BIO", BIOReader.class.getCanonicalName(), ta, 1.0f);


### PR DESCRIPTION
Fix one: now check in the annotator for POS view. If POS is not found, dynamically add it during annotate. 
closes #539 

Fix two: now forces predicted "U" tag to return itself as a mention, instead of keeping looking to the right. It prevents making mistakes when two mentions are adjacent.

Fix three: fixed the mention type attribute added into the predicted mention.

Improvements: added a function to get the predicted mention head out of the predicted extent constituents. Also added support for it in the README.