### PR TITLE
fix minor bug in checking existing constituents

### DIFF
--- a/external/path-lstm/src/main/java/edu/illinois/cs/cogcomp/pipeline/handlers/PathLSTMHandler.java
+++ b/external/path-lstm/src/main/java/edu/illinois/cs/cogcomp/pipeline/handlers/PathLSTMHandler.java
@@ -146,7 +146,8 @@ public class PathLSTMHandler extends Annotator {
                                 Constituent c = new Constituent("Argument", viewName, ta,
                                         finalTokenOffset + span.getFirst(), finalTokenOffset + span.getSecond());
                                 assert span.getFirst() <= span.getSecond() : ta;
-                                List<Constituent> consList = pav.getConstituentsWithSpan(new IntPair(span.getFirst(), span.getSecond()));
+                                List<Constituent> consList = pav.getConstituentsWithSpan(
+                                    new IntPair(finalTokenOffset + span.getFirst(), finalTokenOffset + span.getSecond()));
                                 if (consList.isEmpty()) {
                                     pav.addConstituent(c);
                                 }


### PR DESCRIPTION
We had this bug in the path-lstm annotator, when it looked to see whether a constituent already exists in the TextAnnotation, we checked for an incorrect span: was missing an offset.  Fixed the span now. 