### PR TITLE
Fix RE annotator exception & Add entityType as label in MD

### DIFF
--- a/md/src/main/java/org/cogcomp/md/BIOTester.java
+++ b/md/src/main/java/org/cogcomp/md/BIOTester.java
@@ -344,22 +344,17 @@ public class BIOTester {
             }
         }
         String entityType = goldType;
+        String entityMentionType = curToken.getAttribute("EntityMentionType");
         if (!isGold){
             entityType = mostCommon(predictedTypes);
-        }
-        Constituent wholeMention = new Constituent(entityType, 1.0f, "BIO_Mention", curToken.getTextAnnotation(), startIdx, endIdx);
-        if (isGold){
-            wholeMention.addAttribute("EntityType", goldType);
-            wholeMention.addAttribute("EntityMentionType", curToken.getAttribute("EntityMentionType"));
-        }
-        else{
-            wholeMention.addAttribute("EntityType", mostCommon(predictedTypes));
             String className = classifier.getClass().toString();
             //The className variable is in form "...bio_classifier_[TYPE]"
             //Take the last three characters which stands for the mention level.
-            String emt = className.substring(className.length() - 3).toUpperCase();
-            wholeMention.addAttribute("EntityMentionType", emt);
+            entityMentionType = className.substring(className.length() - 3).toUpperCase();
         }
+        Constituent wholeMention = new Constituent(entityMentionType + "-" + entityType, 1.0f, "BIO_Mention", curToken.getTextAnnotation(), startIdx, endIdx);
+        wholeMention.addAttribute("EntityType", entityType);
+        wholeMention.addAttribute("EntityMentionType", entityMentionType);
         return wholeMention;
     }
 

--- a/md/src/main/java/org/cogcomp/md/BIOTester.java
+++ b/md/src/main/java/org/cogcomp/md/BIOTester.java
@@ -343,8 +343,11 @@ public class BIOTester {
                 endIdx ++;
             }
         }
-
-        Constituent wholeMention = new Constituent(curToken.getLabel(), 1.0f, "BIO_Mention", curToken.getTextAnnotation(), startIdx, endIdx);
+        String entityType = goldType;
+        if (!isGold){
+            entityType = mostCommon(predictedTypes);
+        }
+        Constituent wholeMention = new Constituent(entityType, 1.0f, "BIO_Mention", curToken.getTextAnnotation(), startIdx, endIdx);
         if (isGold){
             wholeMention.addAttribute("EntityType", goldType);
             wholeMention.addAttribute("EntityMentionType", curToken.getAttribute("EntityMentionType"));

--- a/relation-extraction/src/main/java/org/cogcomp/re/RelationAnnotator.java
+++ b/relation-extraction/src/main/java/org/cogcomp/re/RelationAnnotator.java
@@ -84,11 +84,16 @@ public class RelationAnnotator extends Annotator {
         if (!record.hasView(ViewNames.MENTION)) {
             throw new AnnotatorException("Missing required view MENTION");
         }
-        if (record.getView(ViewNames.MENTION).getConstituents().get(0).getAttribute("EntityType").equals("MENTION")) {
+        View mentionView = record.getView(ViewNames.MENTION);
+
+        //Add the original mention view if no mentions are predicted.
+        if (mentionView.getConstituents().size() == 0){
+            record.addView(ViewNames.RELATION, mentionView);
+            return;
+        }
+        if (mentionView.getConstituents().get(0).getAttribute("EntityType").equals("MENTION")) {
             logger.error("The mentions don't have types; this will cause poor performance in predictions.. . ");
         }
-
-        View mentionView = record.getView(ViewNames.MENTION);
         View annotatedTokenView = new SpanLabelView("RE_ANNOTATED", record);
         for (Constituent co : record.getView(ViewNames.TOKENS).getConstituents()) {
             Constituent c = co.cloneForNewView("RE_ANNOTATED");


### PR DESCRIPTION
1) RelationAnnotator now only copy the mentionView for ViewNames.RELATION if no mentions are predicted
2) MentionAnnotator now uses the entity type for each mention as its Constituent label, so that the types show up in the demo