### PR TITLE
Add an XCES reader for MASC dataset

### DIFF
--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/io/IOUtils.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/io/IOUtils.java
@@ -485,4 +485,14 @@ public abstract class IOUtils {
         in.close();
         return obj;
     }
+
+    /**
+     * Changes "/a/b/c/d/e/f/g.h" into "/a/b/.../e/f/g.h",
+     * or "C:\d\e\f\g\h\i\j.k" into "C:\d\e\...\h\i\j.k"
+     * @param path The long path
+     * @return The shortened path
+     */
+    public static String shortenPath(String path) {
+        return path.replaceAll("^(\\w+:|)([\\\\|/][^\\\\|/]+[\\\\|/][^\\\\|/]+[\\\\|/]).*([\\\\|/][^\\\\|/]+[\\\\|/][^\\\\|/]+)$", "$1$2...$3");
+    }
 }

--- a/corpusreaders/README.md
+++ b/corpusreaders/README.md
@@ -46,3 +46,6 @@ mascReader.MascXCESReader is a reader for the entire MASC dataset from Open Amer
 
 It processes Lemma, POS, Sentence, Shallow Parse, NER CoNLL (LOC, ORG, PER),
 and NER Ontonotes (DATE, LOCATION, ORGANIZATION, PERSON) annotations.
+
+The reader takes XCES XML format as input.
+Please check MascXCESReader.java for details on how to generate the input files.

--- a/corpusreaders/README.md
+++ b/corpusreaders/README.md
@@ -16,6 +16,7 @@ provided by the `cogcomp-core-utilities` package.
   - Ontonotes 5.0 Named Entity Reader
   - Ontonotes 5.0 POS Reader
   - TAC KBP reader
+  - MASC Lemma, POS, Shallow Parse, NER Reader
 
 ## Citation
 
@@ -39,3 +40,9 @@ license here: http://nlp.cs.rpi.edu/kbp/2017/index.html
 This reader assumes that the data is structured like PATH-TO-DATA/LANG/TYPE where LANG is one of {cmn,eng,spa} and TYPE
 is either nw or df, for newswire and discussion forum data, respectively.
 
+## MASC Reader
+
+mascReader.MascXCESReader is a reader for the entire MASC dataset from Open American National Corpus.
+
+It processes Lemma, POS, Sentence, Shallow Parse, NER CoNLL (LOC, ORG, PER),
+and NER Ontonotes (DATE, LOCATION, ORGANIZATION, PERSON) annotations.

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/mascReader/MascXCESReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/mascReader/MascXCESReader.java
@@ -1,0 +1,313 @@
+/**
+ * This software is released under the University of Illinois/Research and Academic Use License. See
+ * the LICENSE file in the root folder for details. Copyright (c) 2016
+ *
+ * Developed by: The Cognitive Computation Group University of Illinois at Urbana-Champaign
+ * http://cogcomp.cs.illinois.edu/
+ */
+package edu.illinois.cs.cogcomp.nlp.corpusreaders.mascReader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import edu.illinois.cs.cogcomp.annotation.BasicTextAnnotationBuilder;
+import edu.illinois.cs.cogcomp.core.datastructures.IntPair;
+import edu.illinois.cs.cogcomp.core.datastructures.Pair;
+import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.SpanLabelView;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TokenLabelView;
+import edu.illinois.cs.cogcomp.core.io.IOUtils;
+import edu.illinois.cs.cogcomp.core.utilities.SerializationHelper;
+import edu.illinois.cs.cogcomp.nlp.corpusreaders.AnnotationReader;
+import edu.illinois.cs.cogcomp.nlp.corpusreaders.CorpusReaderConfigurator;
+
+/**
+ * A reader for the entire MASC Open American National Corpus (ANC).
+ * Reads all files (recursively) under a corpus directory
+ * with Lemma, POS, Sentence, Shallow Parse, NER CoNLL (LOC, ORG, PER),
+ * and NER Ontonotes (DATE, LOCATION, ORGANIZATION, PERSON) annotations
+ *
+ * This reader takes as input the XCES XML format annotation files converted by ANC Tool v3.0.2.
+ * To generate the XCES format files:
+ * 1. Download the MASC original files from http://www.anc.org/MASC/download/MASC-3.0.0.zip
+ * 2. Download ANC Tool v3.0.2 from http://www.anc.org/tools/ANCTool-3.0.2.zip
+ * 3. Run ANC Tool with
+ *      GrAF resource header file: MASC-3.0.0/resource-header.xml
+ *      Input directory: MASC-3.0.0/data
+ *      Tab: XML
+ *      Token Type: Penn POS tags
+ *      Annotations: All
+ *      Overlap mode: Nest
+ */
+public class MascXCESReader extends AnnotationReader<TextAnnotation> {
+
+    private static final String TOKEN_ELEMENT = "tok";  // tokens are stored in "tok" XML elements
+    private static final String SENTENCE_ELEMENT = "s";  // sentences are stored in "s" XML elements
+    private static final Function<Element, String> TOKEN_VALUE_PROCESSOR;
+    private static final List<TokenLabelProcessor> TOKEN_LABEL_PROCESSORS;
+    private static final List<SpanLabelProcessor> SPAN_LABEL_PROCESSORS;
+
+    static {
+        TOKEN_VALUE_PROCESSOR = simpleAttrProcessor("string"); // the token itself is the "string" attribute of "tok" elements
+
+        TOKEN_LABEL_PROCESSORS = new ArrayList<>();
+        TOKEN_LABEL_PROCESSORS.add(new TokenLabelProcessor(ViewNames.LEMMA, simpleAttrProcessor("base")));  // Lemma Processor: the token label is the "base" attribute of "tok" elements
+        TOKEN_LABEL_PROCESSORS.add(new TokenLabelProcessor(ViewNames.POS, simpleAttrProcessor("msd")));  // POS Processor: the token label is the "msd" attribute of "tok" elements
+
+        SPAN_LABEL_PROCESSORS = new ArrayList<>();
+        SPAN_LABEL_PROCESSORS.add(new SpanLabelProcessor(SENTENCE_ELEMENT, ViewNames.SENTENCE, elem -> ViewNames.SENTENCE));  // Sentence Processor: the span label is simply ViewNames.SENTENCE
+        SPAN_LABEL_PROCESSORS.add(new SpanLabelProcessor("nchunk", ViewNames.SHALLOW_PARSE, elem -> "NP"));  // Noun Chunk Processor
+        SPAN_LABEL_PROCESSORS.add(new SpanLabelProcessor("vchunk", ViewNames.SHALLOW_PARSE, elem -> "VP"));  // Verb Chunk Processor
+        SPAN_LABEL_PROCESSORS.add(new SpanLabelProcessor("location", ViewNames.NER_CONLL, elem -> "LOC"));  // NER CoNLL Location Processor
+        SPAN_LABEL_PROCESSORS.add(new SpanLabelProcessor("org", ViewNames.NER_CONLL, elem -> "ORG"));  // NER CoNLL Organization Processor
+        SPAN_LABEL_PROCESSORS.add(new SpanLabelProcessor("person", ViewNames.NER_CONLL, elem -> "PER"));  // NER CoNLL Person Processor
+        SPAN_LABEL_PROCESSORS.add(new SpanLabelProcessor("date", ViewNames.NER_ONTONOTES, elem -> "DATE"));  // NER Ontonotes Date Processor
+        SPAN_LABEL_PROCESSORS.add(new SpanLabelProcessor("location", ViewNames.NER_ONTONOTES, elem -> "LOCATION"));  // NER Ontonotes Location Processor
+        SPAN_LABEL_PROCESSORS.add(new SpanLabelProcessor("org", ViewNames.NER_ONTONOTES, elem -> "ORGANIZATION"));  // NER Ontonotes Organization Processor
+        SPAN_LABEL_PROCESSORS.add(new SpanLabelProcessor("person", ViewNames.NER_ONTONOTES, elem -> "PERSON"));  // NER Ontonotes Person Processor
+    }
+
+    private static Logger logger = LoggerFactory.getLogger(MascXCESReader.class);
+    private List<TextAnnotation> textAnnotations = new ArrayList<>();
+
+    /**
+     * This expects a directory that contains XCES format files.
+     * @param corpusName The name of the corpus, e.g. MASC-3.0.0
+     * @param corpusDirectory The folder of the source files
+     * @param fileExtension Should be ".xml" for the XCES XML source files
+     */
+    public MascXCESReader(String corpusName, String corpusDirectory, String fileExtension) {
+        super(CorpusReaderConfigurator.buildResourceManager(corpusName, corpusDirectory, corpusDirectory, fileExtension, fileExtension));
+
+        this.currentAnnotationId = 0;
+
+        String[] sourceFiles;
+        try {
+            sourceFiles = IOUtils.lsFilesRecursive(corpusDirectory, file ->
+                    file.isDirectory() || file.getAbsolutePath().endsWith(fileExtension));
+        } catch (IOException e) {
+            logger.error("Error listing directory.");
+            logger.error(e.getMessage());
+            return;
+        }
+
+        Path corpusAbsolutePath = Paths.get(corpusDirectory).toAbsolutePath();
+        Arrays.sort(sourceFiles);
+        for (String file : sourceFiles) {
+            try {
+                textAnnotations.add(loadAnnotationFile(
+                        corpusName,
+                        file,
+                        corpusAbsolutePath.relativize(Paths.get(file)).toString()
+                ));
+            }
+            catch (ParserConfigurationException e) {
+                logger.error("[" + IOUtils.shortenPath(file) + "] Error initializing XML parser.");
+                logger.error(e.getMessage());
+            }
+            catch (IOException e) {
+                logger.error("[" + IOUtils.shortenPath(file) + "] Error reading file.");
+                logger.error(e.getMessage());
+            }
+            catch (SAXException e) {
+                logger.error("[" + IOUtils.shortenPath(file) + "] Error parsing XML file.");
+            }
+            catch (Exception e) {
+                logger.error("[" + IOUtils.shortenPath(file) + "] Error processing file.");
+                StringWriter sw = new StringWriter();
+                e.printStackTrace(new PrintWriter(sw));
+                logger.error(sw.toString());
+            }
+        }
+    }
+
+    private static TextAnnotation loadAnnotationFile(String corpusName, String filename, String textId) throws Exception {
+        final String TOKEN_IDENTIFIER_KEY = "id";
+
+        // Parse the XML file into DOM
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(new File(filename));
+        doc.getDocumentElement().normalize();  // Merge adjacent texts with no tags between
+
+        List<String> tokens = new ArrayList<>();
+        Map<String, List<Pair<Integer, String>>> tokenLabels = new HashMap<>();
+        for (TokenLabelProcessor processor : TOKEN_LABEL_PROCESSORS) {
+            tokenLabels.putIfAbsent(processor.getViewName(), new ArrayList<>());
+        }
+
+        int currentTokenId = 0;
+        NodeList tokenNodes = doc.getElementsByTagName(TOKEN_ELEMENT);
+        for (int i = 0; i < tokenNodes.getLength(); ++i) {
+            Element tokenNode = (Element)tokenNodes.item(i);
+
+            String tokenLabel = TOKEN_VALUE_PROCESSOR.apply(tokenNode);
+            if (tokenLabel == null) {
+                continue;
+            }
+            tokens.add(tokenLabel);
+
+            for (TokenLabelProcessor processor : TOKEN_LABEL_PROCESSORS) {
+                String label = processor.getProcessor().apply(tokenNode);
+                if (label != null) {
+                    tokenLabels.get(processor.getViewName()).add(new Pair<>(currentTokenId, label));
+                }
+            }
+
+            tokenNode.setUserData(TOKEN_IDENTIFIER_KEY, currentTokenId, null);
+            currentTokenId += 1;
+        }
+
+        Map<String, List<Pair<IntPair, String>>> spanLabels = new HashMap<>();
+
+        for (SpanLabelProcessor processor : SPAN_LABEL_PROCESSORS) {
+            spanLabels.putIfAbsent(processor.getViewName(), new ArrayList<>());
+
+            NodeList spanNodes = doc.getElementsByTagName(processor.getElementName());
+            for (int i = 0; i < spanNodes.getLength(); ++i) {
+                Element spanNode = (Element)spanNodes.item(i);
+
+                String label = processor.getProcessor().apply(spanNode);
+                if (label != null) {
+                    // A span label covers all the (direct or indirect) child "tok" elements
+                    NodeList coveredTokenNodes = spanNode.getElementsByTagName(TOKEN_ELEMENT);
+
+                    List<Integer> coveredTokenIds = new ArrayList<>();
+                    for (int j = 0; j < coveredTokenNodes.getLength(); ++j) {
+                        Object tokenId = coveredTokenNodes.item(j).getUserData(TOKEN_IDENTIFIER_KEY);
+                        if (tokenId != null) {
+                            coveredTokenIds.add((int)tokenId);
+                        }
+                    }
+
+                    // and the span is from the minimum child id to the maximum child id + 1
+                    if (coveredTokenIds.size() > 0) {
+                        int beginToken = coveredTokenIds.stream().reduce(Integer::min).orElseThrow(NoSuchElementException::new);
+                        int endToken = coveredTokenIds.stream().reduce(Integer::max).orElseThrow(NoSuchElementException::new);
+                        spanLabels.get(processor.getViewName()).add(new Pair<>(new IntPair(beginToken, endToken + 1), label));
+                    }
+                }
+            }
+        }
+
+        TextAnnotation ta = BasicTextAnnotationBuilder.createTextAnnotationFromTokens(
+                corpusName, textId, Collections.singletonList(tokens.toArray(new String[0])));
+
+        for (TokenLabelProcessor processor : TOKEN_LABEL_PROCESSORS) {
+            createTokenLabelView(tokenLabels.get(processor.getViewName()).stream(), ta, processor.getViewName());
+        }
+
+        for (SpanLabelProcessor processor : SPAN_LABEL_PROCESSORS) {
+            createSpanLabelView(spanLabels.get(processor.getViewName()).stream(), ta, processor.getViewName(), true);  // span labels in MASC dataset might overlap
+        }
+
+        return ta;
+    }
+
+    /**
+     * Helper for create a processor function that take a particular attribute of the element as the label
+     */
+    private static Function<Element, String> simpleAttrProcessor(String attr) {
+        return elem -> Optional
+                .ofNullable(elem.getAttributes().getNamedItem(attr))  // the label is the `attr` attribute of the element
+                .map(Node::getNodeValue)
+                .orElse(null);  // or don't create the label if the attribute doesn't exist
+    }
+
+    /**
+     * Helper for create a TokenLabelView from a stream of token labels
+     */
+    private static int createTokenLabelView(
+            Stream<Pair<Integer, String>> tokenLabels,
+            TextAnnotation ta,
+            String viewName) {
+        TokenLabelView view = new TokenLabelView(viewName, "GoldStandard", ta, 1.0);
+        tokenLabels.forEach(label -> view.addTokenLabel(label.getFirst(), label.getSecond(), 1.0));
+        ta.addView(viewName, view);
+        return view.count();
+    }
+
+    /**
+     * Helper for create a SpanLabelView from a stream of span labels
+     */
+    private static int createSpanLabelView(
+            Stream<Pair<IntPair, String>> spans,
+            TextAnnotation ta,
+            String viewName,
+            boolean allowOverlapping) {
+        SpanLabelView view = new SpanLabelView(viewName, "GoldStandard", ta, 1.0, allowOverlapping);
+        spans.forEach(span -> view.addSpanLabel(
+                span.getFirst().getFirst(), span.getFirst().getSecond(), span.getSecond(), 1.0));
+        ta.addView(viewName, view);
+        return view.count();
+    }
+
+    @Override
+    protected void initializeReader() {}
+
+    @Override
+    public boolean hasNext() {
+        return textAnnotations.size() > currentAnnotationId;
+    }
+
+    @Override
+    public TextAnnotation next() {
+        return textAnnotations.get(currentAnnotationId++);
+    }
+
+    @Override
+    public String generateReport() {
+        StringBuilder builder = new StringBuilder();
+        builder
+                .append("Number of TextAnnotations generated: ")
+                .append(textAnnotations.size())
+                .append(System.lineSeparator());
+        builder
+                .append("Check INFO logs for further details.")
+                .append(System.lineSeparator());
+        return builder.toString();
+    }
+
+    public static void main(String[] args) throws Exception {
+        String corpusDirectory = "/shared/corpora/corporaWeb/written/eng/MASC-3.0.0/xces";
+        String outputDirectory = "/shared/corpora/corporaWeb/written/eng/MASC-3.0.0/json";
+        if (args.length >= 2) {
+            corpusDirectory = args[0];
+            outputDirectory = args[1];
+        }
+
+        MascXCESReader reader = new MascXCESReader("MASC-3.0.0", corpusDirectory, ".xml");
+        for (TextAnnotation ta : reader) {
+            String outputFile = Paths.get(outputDirectory, ta.getId()).toAbsolutePath().toString();
+            new File(outputFile).getParentFile().mkdirs();
+            SerializationHelper.serializeTextAnnotationToFile(ta, outputFile + ".json", true, true);
+        }
+    }
+}

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/mascReader/SpanLabelProcessor.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/mascReader/SpanLabelProcessor.java
@@ -1,0 +1,38 @@
+/**
+ * This software is released under the University of Illinois/Research and Academic Use License. See
+ * the LICENSE file in the root folder for details. Copyright (c) 2016
+ *
+ * Developed by: The Cognitive Computation Group University of Illinois at Urbana-Champaign
+ * http://cogcomp.cs.illinois.edu/
+ */
+package edu.illinois.cs.cogcomp.nlp.corpusreaders.mascReader;
+
+import org.w3c.dom.Element;
+
+import java.util.function.Function;
+
+import edu.illinois.cs.cogcomp.core.datastructures.Triple;
+
+/**
+ * A SpanLabelProcessor captures a rule of producing span labels from a particular kind of XML elements
+ * It has an elementName to indicate the XML tag name for the span element (e.g. nchunk),
+ * a viewName to indicate the target TextAnnotation view (e.g. ViewNames.SHALLOW_PARSE),
+ * and a processor function on one such element that returns a span label String
+ */
+class SpanLabelProcessor extends Triple<String, String, Function<Element, String>> {
+    public SpanLabelProcessor(String elementName, String viewName, Function<Element, String> processor) {
+        super(elementName, viewName, processor);
+    }
+
+    public String getElementName() {
+        return getFirst();
+    }
+
+    public String getViewName() {
+        return getSecond();
+    }
+
+    public Function<Element, String> getProcessor() {
+        return getThird();
+    }
+}

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/mascReader/TokenLabelProcessor.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/mascReader/TokenLabelProcessor.java
@@ -1,0 +1,33 @@
+/**
+ * This software is released under the University of Illinois/Research and Academic Use License. See
+ * the LICENSE file in the root folder for details. Copyright (c) 2016
+ *
+ * Developed by: The Cognitive Computation Group University of Illinois at Urbana-Champaign
+ * http://cogcomp.cs.illinois.edu/
+ */
+package edu.illinois.cs.cogcomp.nlp.corpusreaders.mascReader;
+
+import org.w3c.dom.Element;
+
+import java.util.function.Function;
+
+import edu.illinois.cs.cogcomp.core.datastructures.Pair;
+
+/**
+ * A TokenLabelProcessor captures a rule of producing a token label from a token XML element
+ * It has a viewName to indicate the target TextAnnotation view (e.g. ViewNames.POS),
+ * and a processor function on a token XML element that returns a token label String
+ */
+class TokenLabelProcessor extends Pair<String, Function<Element, String>> {
+    public TokenLabelProcessor(String viewName, Function<Element, String> processor) {
+        super(viewName, processor);
+    }
+
+    public String getViewName() {
+        return getFirst();
+    }
+
+    public Function<Element, String> getProcessor() {
+        return getSecond();
+    }
+}

--- a/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/mascReaderTests/MascXCESReaderTest.java
+++ b/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/mascReaderTests/MascXCESReaderTest.java
@@ -12,6 +12,7 @@ import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.file.Paths;
 import java.util.List;
 
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
@@ -19,13 +20,17 @@ import edu.illinois.cs.cogcomp.core.datastructures.textannotation.Constituent;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
 import edu.illinois.cs.cogcomp.nlp.corpusreaders.mascReader.MascXCESReader;
 
+/**
+ * Please change CORPUS_DIRECTORY if your MASC XCES XML files are stored elsewhere
+ */
 public class MascXCESReaderTest {
+    private static final String CORPUS_DIRECTORY = "/shared/corpora/corporaWeb/written/eng/MASC-3.0.0/xces";
 
     @Test
     public void testCreateTextAnnotation() throws Exception {
         Logger.getLogger(MascXCESReader.class).setLevel(Level.INFO);
 
-        MascXCESReader cnr = new MascXCESReader("", "/shared/corpora/corporaWeb/written/eng/MASC-3.0.0/xces/written/twitter", ".xml");
+        MascXCESReader cnr = new MascXCESReader("", Paths.get(CORPUS_DIRECTORY, "written/twitter").toString(), ".xml");
 
         TextAnnotation ta = cnr.next();
 

--- a/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/mascReaderTests/MascXCESReaderTest.java
+++ b/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/mascReaderTests/MascXCESReaderTest.java
@@ -1,0 +1,72 @@
+/**
+ * This software is released under the University of Illinois/Research and Academic Use License. See
+ * the LICENSE file in the root folder for details. Copyright (c) 2016
+ *
+ * Developed by: The Cognitive Computation Group University of Illinois at Urbana-Champaign
+ * http://cogcomp.cs.illinois.edu/
+ */
+package edu.illinois.cs.cogcomp.nlp.corpusreaders.mascReaderTests;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.Constituent;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
+import edu.illinois.cs.cogcomp.nlp.corpusreaders.mascReader.MascXCESReader;
+
+public class MascXCESReaderTest {
+
+    @Test
+    public void testCreateTextAnnotation() throws Exception {
+        Logger.getLogger(MascXCESReader.class).setLevel(Level.INFO);
+
+        MascXCESReader cnr = new MascXCESReader("", "/shared/corpora/corporaWeb/written/eng/MASC-3.0.0/xces/written/twitter", ".xml");
+
+        TextAnnotation ta = cnr.next();
+
+        List<Constituent> tokens = ta.getView(ViewNames.TOKENS).getConstituents();
+        Assert.assertEquals(tokens.size(), 13390);  // tok 13390
+        Assert.assertEquals(tokens.get(1).toString(), "setting");
+
+        List<Constituent> lemma = ta.getView(ViewNames.LEMMA).getConstituents();
+        Assert.assertEquals(lemma.size(), 13376);  // base= 13376
+        Assert.assertEquals(lemma.get(1).getLabel(), "set");
+
+        List<Constituent> pos = ta.getView(ViewNames.POS).getConstituents();
+        Assert.assertEquals(pos.size(), 13390);  // msd= 13390
+        Assert.assertEquals(pos.get(1).getLabel(), "VBG");
+
+        List<Constituent> sentences = ta.getView(ViewNames.SENTENCE).getConstituents();
+        Assert.assertEquals(sentences.size(), 1046);  // s 1046
+        Assert.assertEquals(sentences.get(0).getStartSpan(), 0);
+        Assert.assertEquals(sentences.get(0).getEndSpan(), 25);
+
+        List<Constituent> shallowParse = ta.getView(ViewNames.SHALLOW_PARSE).getConstituents();
+        Assert.assertEquals(shallowParse.size(), 5504);  // nchunk 3551, vchunk 1953
+        Assert.assertEquals(shallowParse.get(0).getStartSpan(), 1);
+        Assert.assertEquals(shallowParse.get(0).getEndSpan(), 2);
+        Assert.assertEquals(shallowParse.get(0).getLabel(), "VP");
+
+        List<Constituent> ner = ta.getView(ViewNames.NER_CONLL).getConstituents();
+        Assert.assertEquals(ner.size(), 288);  // location 93, org 112, person 83
+        Assert.assertEquals(ner.get(0).getStartSpan(), 379);  // Singapore
+        Assert.assertEquals(ner.get(0).getEndSpan(), 380);
+        Assert.assertEquals(ner.get(0).getLabel(), "LOC");
+
+        List<Constituent> nerOntonotes = ta.getView(ViewNames.NER_ONTONOTES).getConstituents();
+        Assert.assertEquals(nerOntonotes.size(), 408);  // date 120, location 93, org 112, person 83
+        Assert.assertEquals(nerOntonotes.get(3).getStartSpan(), 379);  // Singapore
+        Assert.assertEquals(nerOntonotes.get(3).getEndSpan(), 380);
+        Assert.assertEquals(nerOntonotes.get(3).getLabel(), "LOCATION");
+
+        Assert.assertTrue(cnr.hasNext());
+        cnr.next();
+
+        Assert.assertFalse(cnr.hasNext());
+    }
+}


### PR DESCRIPTION
A reader for the entire MASC Open American National Corpus (ANC).
This reader takes as input the XCES XML format annotation files converted by ANC Tool v3.0.2.
See MascXCESReader.java for details on how to generate such files from the MASC source files.