### PR TITLE
Fix iss #609: temporal component cannot capture obvious timexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ edison/wordnet/
 **/.project
 **/.classpath
 *~
+
+# lbjava auto-generated files
+question-type/src/main/java/edu/illinois/cs/cogcomp/question_typer/lbjava
+ner/src/main/java/edu/illinois/cs/cogcomp/ner/LbjFeatures
+relation-extraction/src/main/java/org/cogcomp/re/LbjGen

--- a/temporal-normalizer/src/main/java/edu/illinois/cs/cogcomp/temporal/normalizer/main/Demo.java
+++ b/temporal-normalizer/src/main/java/edu/illinois/cs/cogcomp/temporal/normalizer/main/Demo.java
@@ -10,65 +10,80 @@ import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.nlp.tokenizer.StatefulTokenizer;
 import edu.illinois.cs.cogcomp.nlp.utility.TokenizerTextAnnotationBuilder;
 import edu.illinois.cs.cogcomp.pos.POSAnnotator;
+import org.apache.commons.cli.*;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class Demo {
-    public static void main (String []args) throws IOException, AnnotatorException {
-        String text = "The flu season is winding down, and it has killed 105 children so far - about the average toll.\n" +
-                "\n" +
-                "The season started about a month earlier than usual, sparking concerns it might turn into the worst in " +
-                "a decade. It ended up being very hard on the elderly, but was moderately severe overall, according to " +
-                "the Centers for Disease Control and Prevention.\n" +
-                "\n" +
-                "Six of the pediatric deaths were reported in the last week, and it's possible there will be more, said " +
-                "the CDC's Dr. Michael Jhung said Friday.\n" +
-                "\n" +
-                "Roughly 100 children die in an average flu season. One exception was the swine flu pandemic of " +
-                "2009-2010, when 348 children died.\n" +
-                "\n" +
-                "The CDC recommends that all children ages 6 months and older be vaccinated against flu each season, " +
-                "though only about half get a flu shot or nasal spray.\n" +
-                "\n" +
-                "All but four of the children who died were old enough to be vaccinated, but 90 percent of them did " +
-                "not get vaccinated, CDC officials said.\n" +
-                "\n" +
-                "This year's vaccine was considered effective in children, though it didn't work very well in older " +
-                "people. And the dominant flu strain early in the season was one that tends to " +
-                "cause more severe illness.\n" +
-                "\n" +
-                "The government only does a national flu death count for children. But it does track hospitalization " +
-                "rates for people 65 and older, and those statistics have been grim.\n" +
-                "\n" +
-                "In that group, 177 out of every 100,000 were hospitalized with flu-related illness in the past " +
-                "several months. That's more than 2 1/2 times higher than any other recent season.\n" +
-                "\n" +
-                "This flu season started in early December, a month earlier than usual, and peaked by the end " +
-                "of year. Since then, flu reports have been dropping off throughout the country.\n" +
-                "\n" +
-                "\"We appear to be getting close to the end of flu season,\" Jhung said.";
-        TextAnnotationBuilder tab = new TokenizerTextAnnotationBuilder(new StatefulTokenizer());
-        TextAnnotation ta = tab.createTextAnnotation("corpus", "id", text);
-        POSAnnotator annotator = new POSAnnotator();
+    public static void main (String[] args) throws IOException, AnnotatorException {
+        Options options = new Options();
+        Option inputtext = new Option("t", "text", true, "input text to be processed");
+        inputtext.setRequired(false);
+        options.addOption(inputtext);
+
+        CommandLineParser parser = new DefaultParser();
+        HelpFormatter formatter = new HelpFormatter();
         try {
-            annotator.getView(ta);
-        } catch (AnnotatorException e) {
-            fail("AnnotatorException thrown!\n" + e.getMessage());
-        }
-        Properties rmProps = new TemporalChunkerConfigurator().getDefaultConfig().getProperties();
-        rmProps.setProperty("useHeidelTime", "False");
-        TemporalChunkerAnnotator tca = new TemporalChunkerAnnotator(new ResourceManager(rmProps));
-        tca.addView(ta);
-        View temporalViews = ta.getView(ViewNames.TIMEX3);
-        List<Constituent> constituents = temporalViews.getConstituents();
-        System.out.printf("There're %d time expressions (TIMEX) in total.\n",constituents.size());
-        for(Constituent c:constituents){
-            System.out.printf("TIMEX #%d: Type=%s, Value=%s\n",constituents.indexOf(c),c.getAttribute("type"),c.getAttribute("value"));
+            CommandLine cmd = parser.parse(options, args);
+            String defaultText = "The flu season is winding down, and it has killed 105 children so far - about the average toll.\n" +
+                            "\n" +
+                            "The season started about a month earlier than usual, sparking concerns it might turn into the worst in " +
+                            "a decade. It ended up being very hard on the elderly, but was moderately severe overall, according to " +
+                            "the Centers for Disease Control and Prevention.\n" +
+                            "\n" +
+                            "Six of the pediatric deaths were reported in the last week, and it's possible there will be more, said " +
+                            "the CDC's Dr. Michael Jhung said Friday.\n" +
+                            "\n" +
+                            "Roughly 100 children die in an average flu season. One exception was the swine flu pandemic of " +
+                            "2009-2010, when 348 children died.\n" +
+                            "\n" +
+                            "The CDC recommends that all children ages 6 months and older be vaccinated against flu each season, " +
+                            "though only about half get a flu shot or nasal spray.\n" +
+                            "\n" +
+                            "All but four of the children who died were old enough to be vaccinated, but 90 percent of them did " +
+                            "not get vaccinated, CDC officials said.\n" +
+                            "\n" +
+                            "This year's vaccine was considered effective in children, though it didn't work very well in older " +
+                            "people. And the dominant flu strain early in the season was one that tends to " +
+                            "cause more severe illness.\n" +
+                            "\n" +
+                            "The government only does a national flu death count for children. But it does track hospitalization " +
+                            "rates for people 65 and older, and those statistics have been grim.\n" +
+                            "\n" +
+                            "In that group, 177 out of every 100,000 were hospitalized with flu-related illness in the past " +
+                            "several months. That's more than 2 1/2 times higher than any other recent season.\n" +
+                            "\n" +
+                            "This flu season started in early December, a month earlier than usual, and peaked by the end " +
+                            "of year. Since then, flu reports have been dropping off throughout the country.\n" +
+                            "\n" +
+                            "\"We appear to be getting close to the end of flu season,\" Jhung said.";
+            String text = cmd.getOptionValue("text",defaultText);
+            TextAnnotationBuilder tab = new TokenizerTextAnnotationBuilder(new StatefulTokenizer());
+            TextAnnotation ta = tab.createTextAnnotation("corpus", "id", text);
+            POSAnnotator annotator = new POSAnnotator();
+            try {
+                annotator.getView(ta);
+            } catch (AnnotatorException e) {
+                fail("AnnotatorException thrown!\n" + e.getMessage());
+            }
+            Properties rmProps = new TemporalChunkerConfigurator().getDefaultConfig().getProperties();
+            rmProps.setProperty("useHeidelTime", "False");
+            TemporalChunkerAnnotator tca = new TemporalChunkerAnnotator(new ResourceManager(rmProps));
+            tca.addView(ta);
+            View temporalViews = ta.getView(ViewNames.TIMEX3);
+            List<Constituent> constituents = temporalViews.getConstituents();
+            System.out.printf("There're %d time expressions (TIMEX) in total.\n",constituents.size());
+            for(Constituent c:constituents){
+                System.out.printf("TIMEX #%d: Text=%s, Type=%s, Value=%s\n",constituents.indexOf(c),c,c.getAttribute("type"),c.getAttribute("value"));
+            }
+        } catch (ParseException e) {
+            System.out.println(e.getMessage());
+            formatter.printHelp("Temporal Normalizer Demo", options);
+            System.exit(1);
         }
     }
 }

--- a/temporal-normalizer/src/main/java/edu/illinois/cs/cogcomp/temporal/normalizer/main/TemporalChunkerAnnotator.java
+++ b/temporal-normalizer/src/main/java/edu/illinois/cs/cogcomp/temporal/normalizer/main/TemporalChunkerAnnotator.java
@@ -27,10 +27,7 @@ import edu.illinois.cs.cogcomp.lbjava.nlp.seg.Token;
 import edu.illinois.cs.cogcomp.pos.LBJavaUtils;
 
 
-import edu.illinois.cs.cogcomp.temporal.normalizer.main.timex2interval.TemporalPhrase;
-import edu.illinois.cs.cogcomp.temporal.normalizer.main.timex2interval.TimexChunk;
-import edu.illinois.cs.cogcomp.temporal.normalizer.main.timex2interval.TimexNames;
-import edu.illinois.cs.cogcomp.temporal.normalizer.main.timex2interval.TimexNormalizer;
+import edu.illinois.cs.cogcomp.temporal.normalizer.main.timex2interval.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.*;
@@ -198,6 +195,15 @@ public class TemporalChunkerAnnotator extends Annotator{
             tagger.discreteValue(lbjtoken);
             logger.debug("{} {}", lbjtoken.toString(), (null == lbjtoken.type) ? "NULL"
                     : lbjtoken.type);
+
+            if(lbjtoken.type.charAt(0) == 'O'){
+                // if this token matches to any month names or day-of-week names (either full names or abbr. names), then force the chunker label to be Begin
+                DateMapping dateMapping = DateMapping.getInstance();
+                String tmp = lbjtoken.form.toLowerCase();
+                if(dateMapping.getHm_month().containsKey(tmp)
+                        ||dateMapping.getHm_month().containsKey(tmp))
+                    lbjtoken.type = "B-null";
+            }
 
             // what happens if we see an Inside tag -- even if it doesn't follow a Before tag
             if (null != lbjtoken.type && lbjtoken.type.charAt(0) == 'I') {

--- a/temporal-normalizer/src/main/java/edu/illinois/cs/cogcomp/temporal/normalizer/main/timex2interval/DateMapping.java
+++ b/temporal-normalizer/src/main/java/edu/illinois/cs/cogcomp/temporal/normalizer/main/timex2interval/DateMapping.java
@@ -14,47 +14,69 @@ import java.util.*;
  */
 public class DateMapping {
 
+	public static DateMapping instance;
+
 	// Create a hash map
 	HashMap<String, String> hm = new HashMap<String, String>();
+	HashMap<String, String> hm_month = new HashMap<String, String>();
+	HashMap<String, String> hm_dayOfWeek = new HashMap<String, String>();
 
+	public static DateMapping getInstance(){
+		if(instance==null)
+			instance = new DateMapping();
+		return instance;
+	}
 	DateMapping() {
-		hm.put("jan", "1");
-		hm.put("january", "1");
-		hm.put("feb", "2");
-		hm.put("february", "2");
-		hm.put("mar", "3");
-		hm.put("march", "3");
-		hm.put("apr", "4");
-		hm.put("april", "4");
-		hm.put("may", "5");
-		hm.put("jun", "6");
-		hm.put("june", "6");
-		hm.put("jul", "7");
-		hm.put("july", "7");
-		hm.put("aug", "8");
-		hm.put("august", "8");
-		hm.put("sept", "9");
-		hm.put("september", "9");
-		hm.put("oct", "10");
-		hm.put("october", "10");
-		hm.put("nov", "11");
-		hm.put("november", "11");
-		hm.put("dec", "12");
-		hm.put("december", "12");
-		hm.put("mon", "1");
-		hm.put("monday", "1");
-		hm.put("tues", "2");
-		hm.put("tuesday", "2");
-		hm.put("wed", "3");
-		hm.put("wednesday", "3");
-		hm.put("thur", "4");
-		hm.put("thursday", "4");
-		hm.put("fri", "5");
-		hm.put("friday", "5");
-		hm.put("sat", "6");
-		hm.put("saturday", "6");
-		hm.put("sun", "7");
-		hm.put("sunday", "8");
+		hm_month.put("jan", "1");
+		hm_month.put("jan.", "1");
+		hm_month.put("january", "1");
+		hm_month.put("feb", "2");
+		hm_month.put("feb.", "2");
+		hm_month.put("february", "2");
+		hm_month.put("mar", "3");
+		hm_month.put("mar.", "3");
+		hm_month.put("march", "3");
+		hm_month.put("apr", "4");
+		hm_month.put("apr.", "4");
+		hm_month.put("april", "4");
+		hm_month.put("may", "5");
+		hm_month.put("jun", "6");
+		hm_month.put("jun.", "6");
+		hm_month.put("june", "6");
+		hm_month.put("jul", "7");
+		hm_month.put("jul.", "7");
+		hm_month.put("july", "7");
+		hm_month.put("aug", "8");
+		hm_month.put("aug.", "8");
+		hm_month.put("august", "8");
+		hm_month.put("sep", "9");
+		hm_month.put("sep.", "9");
+		hm_month.put("sept", "9");
+		hm_month.put("sept.", "9");
+		hm_month.put("september", "9");
+		hm_month.put("oct", "10");
+		hm_month.put("oct.", "10");
+		hm_month.put("october", "10");
+		hm_month.put("nov", "11");
+		hm_month.put("nov.", "11");
+		hm_month.put("november", "11");
+		hm_month.put("dec", "12");
+		hm_month.put("dec.", "12");
+		hm_month.put("december", "12");
+		hm_dayOfWeek.put("mon", "1");
+		hm_dayOfWeek.put("monday", "1");
+		hm_dayOfWeek.put("tues", "2");
+		hm_dayOfWeek.put("tuesday", "2");
+		hm_dayOfWeek.put("wed", "3");
+		hm_dayOfWeek.put("wednesday", "3");
+		hm_dayOfWeek.put("thur", "4");
+		hm_dayOfWeek.put("thursday", "4");
+		hm_dayOfWeek.put("fri", "5");
+		hm_dayOfWeek.put("friday", "5");
+		hm_dayOfWeek.put("sat", "6");
+		hm_dayOfWeek.put("saturday", "6");
+		hm_dayOfWeek.put("sun", "7");
+		hm_dayOfWeek.put("sunday", "7");
 		hm.put("one", "1");
 		hm.put("two", "2");
 		hm.put("three", "3");
@@ -89,6 +111,20 @@ public class DateMapping {
 		hm.put("an", "1");
 		hm.put("a", "1");
 		hm.put("this", "1");
+
+		hm.putAll(hm_month);
+		hm.putAll(hm_dayOfWeek);
 	}
 
+	public HashMap<String, String> getHm() {
+		return hm;
+	}
+
+	public HashMap<String, String> getHm_month() {
+		return hm_month;
+	}
+
+	public HashMap<String, String> getHm_dayOfWeek() {
+		return hm_dayOfWeek;
+	}
 }

--- a/temporal-normalizer/src/main/java/edu/illinois/cs/cogcomp/temporal/normalizer/main/timex2interval/ModifiedDate.java
+++ b/temporal-normalizer/src/main/java/edu/illinois/cs/cogcomp/temporal/normalizer/main/timex2interval/ModifiedDate.java
@@ -104,7 +104,7 @@ public class ModifiedDate {
 		}
 
 		int numterm;
-		DateMapping temp = new DateMapping();
+		DateMapping temp = DateMapping.getInstance();
 		int i;
 		int dayweek;
 		int year;

--- a/temporal-normalizer/src/main/java/edu/illinois/cs/cogcomp/temporal/normalizer/main/timex2interval/Phrase.java
+++ b/temporal-normalizer/src/main/java/edu/illinois/cs/cogcomp/temporal/normalizer/main/timex2interval/Phrase.java
@@ -219,7 +219,7 @@ public class Phrase {
     public static String fullNameDate(String phrase, datetype information) {
         int i;
         int j;
-        DateMapping temp = new DateMapping();
+        DateMapping temp = DateMapping.getInstance();
         String[] passby = new String[3];
         String patternStr = "\\s*((?:\\d{1,4}(?:st|nd|rd|th)?)|" + month + ")\\s*(?:\\s|[/\\-\\.\\,])\\s*((?:\\d{1,4}(?:st|nd|rd|th)?)|" + month + ")\\s*(?:\\s|[/\\-\\.\\,])\\s*((?:\\d{1,4}(?:st|nd|rd|th)?)|" + month + ")\\s*";
         Pattern pattern = Pattern.compile(patternStr);
@@ -408,7 +408,7 @@ public class Phrase {
     public static String halfnamedate(String phrase, datetype information) {
 
         int i;
-        DateMapping temp = new DateMapping();
+        DateMapping temp = DateMapping.getInstance();
 
 
         String patternStr = "\\s*((?:\\d{1,4}(?:st|nd|rd|th)?)|" + month + ")\\s*(?:\\s|[/\\-\\.\\,])\\s*((?:\\d{1,4}(?:st|nd|rd|th)?)|" + month + ")\\s*";
@@ -494,7 +494,7 @@ public class Phrase {
 
     public static String converter(String phrase1) {
         int i;
-        DateMapping temp = new DateMapping();
+        DateMapping temp = DateMapping.getInstance();
         //It records the number of term(Example:day,month,year)
         int numterm = 0;
         String result;

--- a/temporal-normalizer/src/main/java/edu/illinois/cs/cogcomp/temporal/normalizer/main/timex2interval/RelativeDate.java
+++ b/temporal-normalizer/src/main/java/edu/illinois/cs/cogcomp/temporal/normalizer/main/timex2interval/RelativeDate.java
@@ -22,7 +22,7 @@ import static edu.illinois.cs.cogcomp.temporal.normalizer.main.timex2interval.Kn
  */
 public class RelativeDate {
 
-	public static DateMapping temp = new DateMapping();
+	public static DateMapping temp = DateMapping.getInstance();
 
 	/**
 	 * This function converts phrase that contains a relative date: more than xxx, etc

--- a/temporal-normalizer/src/main/java/edu/illinois/cs/cogcomp/temporal/normalizer/main/timex2interval/SetRule.java
+++ b/temporal-normalizer/src/main/java/edu/illinois/cs/cogcomp/temporal/normalizer/main/timex2interval/SetRule.java
@@ -73,7 +73,7 @@ public class SetRule {
         Matcher weekdayPatternMatcher = weekdayPattern.matcher(unitStr);
         Boolean weekdayPatternMatchFound = weekdayPatternMatcher.find();
         if (weekdayPatternMatchFound) {
-            DateMapping weekdayMap = new DateMapping();
+            DateMapping weekdayMap = DateMapping.getInstance();
             res = "XXXX-WXX-"+weekdayMap.hm.get(weekdayPatternMatcher.group(1));
         }
 
@@ -82,7 +82,7 @@ public class SetRule {
         Matcher monthPatternMatcher = monthPattern.matcher(unitStr);
         Boolean monthPatternMatchFound = monthPatternMatcher.find();
         if (monthPatternMatchFound) {
-            DateMapping monthMap = new DateMapping();
+            DateMapping monthMap = DateMapping.getInstance();
             String mapRes = monthMap.hm.get(monthPatternMatcher.group(1));
             mapRes = mapRes.length()==1?"0"+mapRes:mapRes;
             res = "XXXX-"+mapRes;


### PR DESCRIPTION
Issue #609: Temporal Normalizer: does get short forms of months.
For example, it doesn't get this example:
"Feb 14 is valentines day."

This is due to our design. We use a two-step procedure in our normalizer:
1. Use chunker to chunk out time expressions (timex). 
2. Use our normalizer to convert timex-es from surface forms to standard values (e.g., 2018-04-21). The purpose of this design was to reduce the computational time of conventional methods (e.g., HeidelTime). 

However, the cost is that step 1 (chunker) is not perfect and sometimes fails on very easy cases (here "Feb 14" is one example). 

Above is the reason of such behavior. Although it is expected, I think it's worthwhile to at least use some simple rules before we apply the chunker so that we don't make silly mistakes. Specifically, after chunker makes a decision about whether a token is B/I/O, if it's O, then I do a sanity check to see if this token is a month/week-of-day name (or abbr.). If it is indeed such a token, I revert it from O to B.

Now if we feed `-t "Feb. 14 is the Valentines day."` to `edu.illinois.cs.cogcomp.temporal.normalizer.main.Demo`, we get it correctly:
```
There're 1 time expressions (TIMEX) in total.
TIMEX #0: Text=Feb. 14, Type=DATE, Value=2018-02-14
```