### PR TITLE
fix a TextAnnotation builder bug on Windows

### DIFF
--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/BasicTextAnnotationBuilder.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/BasicTextAnnotationBuilder.java
@@ -9,7 +9,6 @@ package edu.illinois.cs.cogcomp.annotation;
 
 import edu.illinois.cs.cogcomp.core.datastructures.IntPair;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
-import edu.illinois.cs.cogcomp.nlp.tokenizer.Tokenizer;
 import edu.illinois.cs.cogcomp.nlp.tokenizer.Tokenizer.Tokenization;
 import org.apache.commons.lang.StringUtils;
 
@@ -116,7 +115,7 @@ public class BasicTextAnnotationBuilder implements TextAnnotationBuilder {
 
                 // The next token should start after a single space
                 tokenStartOffset += sentenceToken.length() + 1;
-                nextSentStartCharOffset = tokenCharEnd + 1; // by end of loop, this should match
+                nextSentStartCharOffset = tokenCharEnd + System.lineSeparator().length(); // by end of loop, this should match
                                                             // start of next sentence
             }
 


### PR DESCRIPTION
On Windows platform, `System.lineSeparator()` is `\r\n` instead of `\n`

This causes issue when creating a TextAnnotation. Every sentence should start with the previous ending character offset plus the size of the lineSeparator, as specified at https://github.com/CogComp/cogcomp-nlp/blob/1267fc72aba945a77249d34787ecb607eaa81f3b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/BasicTextAnnotationBuilder.java#L56

An alternative fix will be replacing the above line with `text += StringUtils.join(sentenceTokens, ' ') + "\n";`

Please let me know which one is a better fix.

I actually lean towards the second one, but I don't know if there is a reason for line 56 to use `System.lineSeparator()` instead of `\n`.

@mssammon @danyaljj 