### PR TITLE
disabled problematic MASC reader test; removed edison test output files.

### DIFF
--- a/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/mascReaderTests/MascXCESReaderTest.java
+++ b/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/mascReaderTests/MascXCESReaderTest.java
@@ -24,9 +24,10 @@ import edu.illinois.cs.cogcomp.nlp.corpusreaders.mascReader.MascXCESReader;
  * Please change CORPUS_DIRECTORY if your MASC XCES XML files are stored elsewhere
  */
 public class MascXCESReaderTest {
-    private static final String CORPUS_DIRECTORY = "/shared/corpora/corporaWeb/written/eng/MASC-3.0.0/xces";
+    private static final String CORPUS_DIRECTORY = "dummy/path"; ///shared/corpora/corporaWeb/written/eng/MASC-3.0.0/xces";
 
-    @Test
+    // commenting '@Test' annotation so it doesn't run automatically
+//    @Test
     public void testCreateTextAnnotation() throws Exception {
         Logger.getLogger(MascXCESReader.class).setLevel(Level.INFO);
 

--- a/edison/src/test/resources/outputFiles/TestBaseLineCounterOutput
+++ b/edison/src/test/resources/outputFiles/TestBaseLineCounterOutput
@@ -1,1 +1,0 @@
-Test Corpus: section0.br

--- a/edison/src/test/resources/outputFiles/TestMikheevCounterOutput
+++ b/edison/src/test/resources/outputFiles/TestMikheevCounterOutput
@@ -1,8 +1,0 @@
-Test Corpus: section0.br
-
-firstCapitalized
-
-notFirstCapitalized
-
-table
-


### PR DESCRIPTION
disabled MASC corpus reader test to avoid failure when run on a non-CCG machine.
removed edison test output files, which I don't think should be in the git repo as they are outputs, and are not invariant across tests (at least not on different machines). 