### PR TITLE
fix the timex bug when may and sat appear as verbs instead of timexes

### DIFF
--- a/temporal-normalizer/src/main/java/edu/illinois/cs/cogcomp/temporal/normalizer/main/TemporalChunkerAnnotator.java
+++ b/temporal-normalizer/src/main/java/edu/illinois/cs/cogcomp/temporal/normalizer/main/TemporalChunkerAnnotator.java
@@ -204,8 +204,16 @@ public class TemporalChunkerAnnotator extends Annotator{
                 if(previous!=null&&previous.getSurfaceForm()!=null)
                     prev_token = previous.getSurfaceForm().toLowerCase();
                 if(dateMapping.getHm_month().containsKey(tmp)
-                        ||dateMapping.getHm_dayOfWeek().containsKey(tmp))// if this token matches to any month names or day-of-week names (either full names or abbr. names), then force the chunker label to be Begin
-                    lbjtoken.type = "B-null";
+                        ||!tmp.equals("sun")&&dateMapping.getHm_dayOfWeek().containsKey(tmp)) {
+                    // if this token matches to any month names or day-of-week names (either full names or abbr. names), then force the chunker label to be Begin
+                    // "Sun" is a bit tricky since the star "Sun" and the day of week "Sunday" are both NNP. We leave it to chunker now.
+                    if(tmp.equals("may")||tmp.equals("sat")){
+                        if(current.getLabel().startsWith("NNP"))
+                            lbjtoken.type = "B-null";
+                    }
+                    else
+                        lbjtoken.type = "B-null";
+                }
                 else if(prev_token!=null
                             && dateMapping.getHm_month().containsKey(prev_token)){// previous token was a "month"
                     if(dateMapping.getHm_dayOfMonth().contains(tmp))// curr token is an ordinal number


### PR DESCRIPTION
Previously, to avoid silly mistakes, I incorporated rules before timex chunker, so that any word matching to month names or week-of-the-day names will be forced to be a timex.

However, I realized that this rule is not accurate. `may` can be either a modal verb, or the month. `sat` can be also the past tence of `sit`. So I have added a POS check now: only those `may`'s or `sat`'s that are NNP will be forced to be timex.

`sun` is a bit tricky, since the star Sun is also NNP. I pick it out of our rules and leave it up to the chunker's decision.