### PR TITLE
A temporary fix to sentence splitter behavior in TokenizerStateMachine when dealing with acronyms; Also fixing tokenizer unit tests to ensure test passing when using windows style line separator

### DIFF
--- a/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/Acronyms.java
+++ b/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/Acronyms.java
@@ -60,7 +60,7 @@ public class Acronyms {
             "Nev", "NV", "N.H", "NH", "N.J", "NJ", "N.M", "NM", "N.Y", "NY", "N.C", "NC", "N.D",
             "ND", "MP", "OH", "Okla", "OK", "Ore", "OR", "pub", "PW", "Pa", "PA", "P.R", "PR",
             "R.I", "RI", "S.C", "SC", "S.D", "SD", "Tenn", "TN", "Tex", "TX", "UT", "Vt", "VT",
-            "Va", "VA", "V.I", "VI", "Wash", "WA", "W.Va", "WV", "Wis", "WI", "Wyo", "WY"};
+            "Va", "VA", "V.I", "VI", "Wash", "WA", "W.Va", "WV", "Wis", "WI", "Wyo", "WY", "Fr"};
 
     // init the abbr data structure.
     static {

--- a/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/TokenizerStateMachine.java
+++ b/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/TokenizerStateMachine.java
@@ -336,7 +336,7 @@ public class TokenizerStateMachine {
                                     if (getCurrent().isAbbr())
                                         return; // previous was upper case, acronym and word
                                                 // continues
-                                    else if (Character.isWhitespace(c) && Character.isLowerCase(nextnextChar))
+                                    else if (Character.isLowerCase(nextnextChar))
                                         return; // when the next char is white space and the next next char
                                                 // is lowercase, we know that the next word is not start of
                                                 // a sentence, so we continue.

--- a/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/TokenizerStateMachine.java
+++ b/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/TokenizerStateMachine.java
@@ -332,9 +332,14 @@ public class TokenizerStateMachine {
                                 } else {
                                     // check for all uppercase and periods back to the start of the
                                     // word or a "-"
+                                    char nextnextChar = peek(2);
                                     if (getCurrent().isAbbr())
                                         return; // previous was upper case, acronym and word
                                                 // continues
+                                    else if (Character.isWhitespace(c) && Character.isLowerCase(nextnextChar))
+                                        return; // when the next char is white space and the next next char
+                                                // is lowercase, we know that the next word is not start of
+                                                // a sentence, so we continue.
                                     else
                                         ; // we will pass through, this is not an acronym, so must
                                           // be a special character.

--- a/tokenizer/src/test/java/edu/illinois/cs/cogcomp/nlp/tokenizer/StatefullTokenizerTest.java
+++ b/tokenizer/src/test/java/edu/illinois/cs/cogcomp/nlp/tokenizer/StatefullTokenizerTest.java
@@ -152,7 +152,8 @@ public class StatefullTokenizerTest {
         IntPair notOffsets = new IntPair(42, 45);
         assertEquals(notOffsets, tokenOffsets[notIndex]);
         int intolerantIndex = 14;
-        IntPair intolerantOffsets = new IntPair(77, 87);
+        int lineSepLength = System.lineSeparator().length();
+        IntPair intolerantOffsets = new IntPair(76 + lineSepLength, 86 + lineSepLength);
         assertEquals(intolerantOffsets, tokenOffsets[intolerantIndex]);
     }
     

--- a/tokenizer/src/test/java/edu/illinois/cs/cogcomp/nlp/tokenizer/StatefullTokenizerTest.java
+++ b/tokenizer/src/test/java/edu/illinois/cs/cogcomp/nlp/tokenizer/StatefullTokenizerTest.java
@@ -378,7 +378,18 @@ public class StatefullTokenizerTest {
         Tokenizer.Tokenization tknzn = tkr.tokenizeTextSpan(text);
         assertEquals(tknzn.getTokens().length, 6);
     }
-    
+
+    /**
+     * Test sentence splitter behavior when a there is a lower cased acronym followed immediately by a dot.
+     */
+    @Test
+    public void testLowerCaseAcronymEndWithDot(){
+        TokenizerTextAnnotationBuilder tab =
+                new TokenizerTextAnnotationBuilder(new StatefulTokenizer(true, true));
+        String text = "I was born in Urbana, Il. in 1992.";
+        TextAnnotation ta = tab.createTextAnnotation(text);
+        assertEquals(ta.getNumberOfSentences(), 1);
+    }
     /**
      * This can be used to just quickly debug when a sentence produces an error.
      * @param args

--- a/tokenizer/src/test/java/edu/illinois/cs/cogcomp/nlp/tokenizer/TokenizerTextAnnotationBuilderTest.java
+++ b/tokenizer/src/test/java/edu/illinois/cs/cogcomp/nlp/tokenizer/TokenizerTextAnnotationBuilderTest.java
@@ -32,13 +32,16 @@ public class TokenizerTextAnnotationBuilderTest {
                 "Mr. Dawkins -- a liberal professor -- doesn't like fundamentalists.   ";
         final String sentB = "He is intolerant of intolerance!";
 
-        final int refSentStartOffset = 71;
-        final int refSentEndOffset = 103;
+        String lineSep = System.lineSeparator();
+        int lineSepLength = lineSep.length();
 
-        final int refTokStartOffset = 77;
+        final int refSentStartOffset = 70 + lineSepLength;
+        final int refSentEndOffset = 102 + lineSepLength;
+
+        final int refTokStartOffset = 76 + lineSepLength;
         final int refTokEndOffset = refTokStartOffset + 10;
 
-        final String text = sentA + System.lineSeparator() + sentB;
+        final String text = sentA + lineSep + sentB;
 
         TextAnnotation ta = bldr.createTextAnnotation("test", "test", text);
 


### PR DESCRIPTION
Adding a rule in [TokenizerStateMachine](https://github.com/CogComp/cogcomp-nlp/blob/master/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/TokenizerStateMachine.java) -- When the current character is a period; the next char is white space; and the next next char is a lower-cased alphabet, (I think) we can safely say that the next word would not be the start of a sentence, so the TSM should not split on the current period.  

This fix resolves #657, but doesn't work on the last example Daniel mentioned in #492. 

> " A Science Hall was built in 1883 under the direction of Fr. Zahm, but in 1950 it was converted to a student union building and named LaFortune Center, after Joseph LaFortune, an oil executive from Tulsa, Oklahoma."

Also fixed tokenizer unit tests to ensure test passing when using windows style line separator (\r\n).
