### PR TITLE
ojAlgo v47

### DIFF
--- a/inference/pom.xml
+++ b/inference/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.ojalgo</groupId>
             <artifactId>ojalgo</artifactId>
-            <version>40.0.0</version>
+            <version>47.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.gurobi</groupId>

--- a/inference/src/main/java/edu/illinois/cs/cogcomp/infer/ilp/OJalgoHook.java
+++ b/inference/src/main/java/edu/illinois/cs/cogcomp/infer/ilp/OJalgoHook.java
@@ -203,9 +203,7 @@ public class OJalgoHook implements ILPSolver {
                 model.addExpression("EqualityConstraint: " + Integer.toString(numConstraints));
         constraint.level(b);
         for (int ind = 0; ind < i.length; ind++) {
-            constraint.setLinearFactor(i[ind], a[ind]);
-            // in jdk8:
-            // constraint.set(i[ind], a[ind])
+            constraint.set(i[ind], a[ind]);
         }
     }
 
@@ -222,9 +220,7 @@ public class OJalgoHook implements ILPSolver {
                 model.addExpression("GreaterThanConstraint: " + Integer.toString(numConstraints));
         constraint.lower(b);
         for (int ind = 0; ind < i.length; ind++) {
-            constraint.setLinearFactor(i[ind], a[ind]);
-            // in jdk8:
-            // constraint.set(i[ind], a[ind]);
+            constraint.set(i[ind], a[ind]);
         }
     }
 
@@ -241,9 +237,7 @@ public class OJalgoHook implements ILPSolver {
                 model.addExpression("LessThanConstraint: " + Integer.toString(numConstraints));
         constraint.upper(b);
         for (int ind = 0; ind < i.length; ind++) {
-            constraint.setLinearFactor(i[ind], a[ind]);
-            // in jdk8:
-            // constraint.set(i[ind], a[ind]);
+            constraint.set(i[ind], a[ind]);
         }
     }
 


### PR DESCRIPTION
Upgrade ojAlgo from v40 to v47.

Info: ojAlgo has 3:d party iterations with CPLEX, GUROBI and MOSEK. If you can detect that any of those solvers are available then all you need to to is `model.addIntegation(INTEGRATION)` to register that integration with ojAlgo, and then that solver will be used. No code changes required.