### PR TITLE
Fix some typos in ner/scripts/annotate.sh

### DIFF
--- a/ner/scripts/annotate.sh
+++ b/ner/scripts/annotate.sh
@@ -63,7 +63,7 @@ done
 for JAR in `ls $LIB/*jar`; do
     cpath="$cpath:$JAR"
 done
-va -classpath  ${cpath} -Xmx12g edu.illinois.cs.cogcomp.ner.NerTagger -annotate $input $output $format $configFile"
+java -classpath  ${cpath} -Xmx12g edu.illinois.cs.cogcomp.ner.NerTagger -annotate $input $output $format "$configFile"
 
 echo "$0: running command '$CMD'..."
 


### PR DESCRIPTION
It looks like some characters had been deleted.